### PR TITLE
Fixed @media query breakpoints

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -27,12 +27,19 @@ const toJS = R.reduce((acc, [k, v]) => {
   return R.mergeWithKey(concatMediaQueries, acc, nativeCSS.convert(v));
 }, {})
 
-
+/*
 const queries = {
   '@media (--breakpoint-not-small)': '@media screen and (min-width: 48em)',
   '@media (--breakpoint-medium)': '@media screen and (min-width: 48em) and (max-width: 64em)',
   '@media (--breakpoint-large)': '@media screen and (min-width: 64em)',
 }
+*/
+
+const queries = {
+  '@media (--breakpoint-not-small)': '@media screen and (min-width: 30em)',
+  '@media (--breakpoint-medium)': '@media screen and (min-width: 30em) and (max-width: 60em)',
+  '@media (--breakpoint-large)': '@media screen and (min-width: 60em)'
+};
 
 const queryKeys = R.keys(queries);
 

--- a/index.js
+++ b/index.js
@@ -2268,71 +2268,71 @@ module.exports = {
     "z-index": "unset"
   },
   "__expression__": {
-    "@media screen and (min-width: 64em)": "(--breakpoint-large)"
+    "@media screen and (min-width: 60em)": "(--breakpoint-large)"
   },
   "aspect_ratio_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "0",
       "position": "relative"
     }
   },
   "aspect_ratio__16x9_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "56.25%"
     }
   },
   "aspect_ratio__9x16_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "177.77%"
     }
   },
   "aspect_ratio__4x3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "75%"
     }
   },
   "aspect_ratio__3x4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "133.33%"
     }
   },
   "aspect_ratio__6x4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "66.6%"
     }
   },
   "aspect_ratio__4x6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "150%"
     }
   },
   "aspect_ratio__8x5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "62.5%"
     }
   },
   "aspect_ratio__5x8_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "160%"
     }
   },
   "aspect_ratio__7x5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "71.42%"
     }
   },
   "aspect_ratio__5x7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "140%"
     }
   },
   "aspect_ratio__1x1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "100%"
     }
   },
   "aspect_ratio__object_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "position": "absolute",
       "top": "0",
       "right": "0",
@@ -2344,357 +2344,357 @@ module.exports = {
     }
   },
   "bg_center_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "background-repeat": "no-repeat",
       "background-position": "center center"
     }
   },
   "bg_top_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "background-repeat": "no-repeat",
       "background-position": "top center"
     }
   },
   "bg_right_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "background-repeat": "no-repeat",
       "background-position": "center right"
     }
   },
   "bg_bottom_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "background-repeat": "no-repeat",
       "background-position": "bottom center"
     }
   },
   "bg_left_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "background-repeat": "no-repeat",
       "background-position": "center left"
     }
   },
   "cover_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "background-size": "cover"
     }
   },
   "contain_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "background-size": "contain"
     }
   },
   "br0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-radius": "0"
     }
   },
   "br1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-radius": ".125rem"
     }
   },
   "br2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-radius": ".25rem"
     }
   },
   "br3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-radius": ".5rem"
     }
   },
   "br4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-radius": "1rem"
     }
   },
   "br_100_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-radius": "100%"
     }
   },
   "br_pill_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-radius": "9999px"
     }
   },
   "br__bottom_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-top-left-radius": "0",
       "border-top-right-radius": "0"
     }
   },
   "br__top_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-bottom-left-radius": "0",
       "border-bottom-right-radius": "0"
     }
   },
   "br__right_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-top-left-radius": "0",
       "border-bottom-left-radius": "0"
     }
   },
   "br__left_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-top-right-radius": "0",
       "border-bottom-right-radius": "0"
     }
   },
   "b__dotted_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-style": "dotted"
     }
   },
   "b__dashed_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-style": "dashed"
     }
   },
   "b__solid_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-style": "solid"
     }
   },
   "b__none_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-style": "none"
     }
   },
   "bw0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-width": "0"
     }
   },
   "bw1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-width": ".125rem"
     }
   },
   "bw2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-width": ".25rem"
     }
   },
   "bw3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-width": ".5rem"
     }
   },
   "bw4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-width": "1rem"
     }
   },
   "bw5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-width": "2rem"
     }
   },
   "bt_0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-top-width": "0"
     }
   },
   "br_0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-right-width": "0"
     }
   },
   "bb_0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-bottom-width": "0"
     }
   },
   "bl_0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-left-width": "0"
     }
   },
   "ba_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-style": "solid",
       "border-width": "1px"
     }
   },
   "bt_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-top-style": "solid",
       "border-top-width": "1px"
     }
   },
   "br_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-right-style": "solid",
       "border-right-width": "1px"
     }
   },
   "bb_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-bottom-style": "solid",
       "border-bottom-width": "1px"
     }
   },
   "bl_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-left-style": "solid",
       "border-left-width": "1px"
     }
   },
   "bn_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "border-style": "none",
       "border-width": "0"
     }
   },
   "shadow_1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "box-shadow": "0px 0px 4px 2px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "shadow_2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "box-shadow": "0px 0px 8px 2px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "shadow_3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "box-shadow": "2px 2px 4px 2px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "shadow_4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "box-shadow": "2px 2px 8px 0px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "shadow_5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "box-shadow": "4px 4px 8px 0px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "cl_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "clear": "left"
     }
   },
   "cr_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "clear": "right"
     }
   },
   "cb_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "clear": "both"
     }
   },
   "cn_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "clear": "none"
     }
   },
   "top_0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "top": "0"
     }
   },
   "left_0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "left": "0"
     }
   },
   "right_0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "right": "0"
     }
   },
   "bottom_0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "bottom": "0"
     }
   },
   "top_1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "top": "1rem"
     }
   },
   "left_1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "left": "1rem"
     }
   },
   "right_1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "right": "1rem"
     }
   },
   "bottom_1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "bottom": "1rem"
     }
   },
   "top_2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "top": "2rem"
     }
   },
   "left_2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "left": "2rem"
     }
   },
   "right_2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "right": "2rem"
     }
   },
   "bottom_2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "bottom": "2rem"
     }
   },
   "top__1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "top": "-1rem"
     }
   },
   "right__1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "right": "-1rem"
     }
   },
   "bottom__1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "bottom": "-1rem"
     }
   },
   "left__1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "left": "-1rem"
     }
   },
   "top__2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "top": "-2rem"
     }
   },
   "right__2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "right": "-2rem"
     }
   },
   "bottom__2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "bottom": "-2rem"
     }
   },
   "left__2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "left": "-2rem"
     }
   },
   "absolute__fill_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "top": "0",
       "right": "0",
       "bottom": "0",
@@ -2702,1581 +2702,1581 @@ module.exports = {
     }
   },
   "dn_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "display": "none"
     }
   },
   "di_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "display": "inline"
     }
   },
   "db_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "display": "block"
     }
   },
   "dib_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "display": "inline-block"
     }
   },
   "dit_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "display": "inline-table"
     }
   },
   "dt_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "display": "table"
     }
   },
   "dtc_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "display": "table-cell"
     }
   },
   "dt_row_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "display": "table-row"
     }
   },
   "dt_row_group_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "display": "table-row-group"
     }
   },
   "dt_column_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "display": "table-column"
     }
   },
   "dt_column_group_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "display": "table-column-group"
     }
   },
   "dt__fixed_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "table-layout": "fixed",
       "width": "100%"
     }
   },
   "flex_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "display": "flex"
     }
   },
   "inline_flex_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "display": "inline-flex"
     }
   },
   "flex_auto_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "flex": "1 1 auto",
       "min-width": "0",
       "min-height": "0"
     }
   },
   "flex_none_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "flex": "none"
     }
   },
   "flex_column_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "flex-direction": "column"
     }
   },
   "flex_row_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "flex-direction": "row"
     }
   },
   "flex_wrap_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "flex-wrap": "wrap"
     }
   },
   "items_start_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-items": "flex-start"
     }
   },
   "items_end_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-items": "flex-end"
     }
   },
   "items_center_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-items": "center"
     }
   },
   "items_baseline_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-items": "baseline"
     }
   },
   "items_stretch_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-items": "stretch"
     }
   },
   "self_start_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-self": "flex-start"
     }
   },
   "self_end_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-self": "flex-end"
     }
   },
   "self_center_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-self": "center"
     }
   },
   "self_baseline_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-self": "baseline"
     }
   },
   "self_stretch_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-self": "stretch"
     }
   },
   "justify_start_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "justify-content": "flex-start"
     }
   },
   "justify_end_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "justify-content": "flex-end"
     }
   },
   "justify_center_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "justify-content": "center"
     }
   },
   "justify_between_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "justify-content": "space-between"
     }
   },
   "justify_around_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "justify-content": "space-around"
     }
   },
   "content_start_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-content": "flex-start"
     }
   },
   "content_end_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-content": "flex-end"
     }
   },
   "content_center_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-content": "center"
     }
   },
   "content_between_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-content": "space-between"
     }
   },
   "content_around_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-content": "space-around"
     }
   },
   "content_stretch_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "align-content": "stretch"
     }
   },
   "order_0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "order": "0"
     }
   },
   "order_1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "order": "1"
     }
   },
   "order_2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "order": "2"
     }
   },
   "order_3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "order": "3"
     }
   },
   "order_4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "order": "4"
     }
   },
   "order_5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "order": "5"
     }
   },
   "order_6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "order": "6"
     }
   },
   "order_7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "order": "7"
     }
   },
   "order_8_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "order": "8"
     }
   },
   "order_last_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "order": "99999"
     }
   },
   "fl_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "float": "left",
       "_display": "inline"
     }
   },
   "fr_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "float": "right",
       "_display": "inline"
     }
   },
   "fn_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "float": "none"
     }
   },
   "i_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-style": "italic"
     }
   },
   "fs_normal_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-style": "normal"
     }
   },
   "normal_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-weight": "normal"
     }
   },
   "b_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-weight": "bold"
     }
   },
   "fw1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-weight": "100"
     }
   },
   "fw2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-weight": "200"
     }
   },
   "fw3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-weight": "300"
     }
   },
   "fw4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-weight": "400"
     }
   },
   "fw5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-weight": "500"
     }
   },
   "fw6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-weight": "600"
     }
   },
   "fw7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-weight": "700"
     }
   },
   "fw8_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-weight": "800"
     }
   },
   "fw9_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-weight": "900"
     }
   },
   "h1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "1rem"
     }
   },
   "h2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "2rem"
     }
   },
   "h3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "4rem"
     }
   },
   "h4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "8rem"
     }
   },
   "h5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "16rem"
     }
   },
   "h_25_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "25%"
     }
   },
   "h_50_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "50%"
     }
   },
   "h_75_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "75%"
     }
   },
   "h_100_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "100%"
     }
   },
   "min_h_100_ns": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "min-height": "100%"
     }
   },
   "vh_25_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "25vh"
     }
   },
   "vh_50_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "50vh"
     }
   },
   "vh_75_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "75vh"
     }
   },
   "vh_100_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "100vh"
     }
   },
   "min_vh_100_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "min-height": "100vh"
     }
   },
   "h_auto_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "auto"
     }
   },
   "h_inherit_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "height": "inherit"
     }
   },
   "tracked_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "letter-spacing": ".1em"
     }
   },
   "tracked_tight_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "letter-spacing": "-.05em"
     }
   },
   "tracked_mega_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "letter-spacing": ".25em"
     }
   },
   "lh_solid_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "line-height": "1"
     }
   },
   "lh_title_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "line-height": "1.25"
     }
   },
   "lh_copy_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "line-height": "1.5"
     }
   },
   "mw_100_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "100%"
     }
   },
   "mw1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "1rem"
     }
   },
   "mw2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "2rem"
     }
   },
   "mw3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "4rem"
     }
   },
   "mw4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "8rem"
     }
   },
   "mw5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "16rem"
     }
   },
   "mw6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "32rem"
     }
   },
   "mw7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "48rem"
     }
   },
   "mw8_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "64rem"
     }
   },
   "mw9_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "96rem"
     }
   },
   "mw_none_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "none"
     }
   },
   "outline_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "outline": "1px solid"
     }
   },
   "outline_transparent_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "outline": "1px solid transparent"
     }
   },
   "outline_0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "outline": "0"
     }
   },
   "overflow_visible_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "overflow": "visible"
     }
   },
   "overflow_hidden_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "overflow": "hidden"
     }
   },
   "overflow_scroll_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "overflow": "scroll"
     }
   },
   "overflow_auto_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "overflow": "auto"
     }
   },
   "overflow_x_visible_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "overflow-x": "visible"
     }
   },
   "overflow_x_hidden_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "overflow-x": "hidden"
     }
   },
   "overflow_x_scroll_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "overflow-x": "scroll"
     }
   },
   "overflow_x_auto_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "overflow-x": "auto"
     }
   },
   "overflow_y_visible_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "overflow-y": "visible"
     }
   },
   "overflow_y_hidden_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "overflow-y": "hidden"
     }
   },
   "overflow_y_scroll_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "overflow-y": "scroll"
     }
   },
   "overflow_y_auto_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "overflow-y": "auto"
     }
   },
   "static_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "position": "static"
     }
   },
   "relative_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "position": "relative"
     }
   },
   "absolute_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "position": "absolute"
     }
   },
   "fixed_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "position": "fixed"
     }
   },
   "rotate_45_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "transform": "rotate(45deg)"
     }
   },
   "rotate_90_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "transform": "rotate(90deg)"
     }
   },
   "rotate_135_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "transform": "rotate(135deg)"
     }
   },
   "rotate_180_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "transform": "rotate(180deg)"
     }
   },
   "rotate_225_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "transform": "rotate(225deg)"
     }
   },
   "rotate_270_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "transform": "rotate(270deg)"
     }
   },
   "rotate_315_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "transform": "rotate(315deg)"
     }
   },
   "pa0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding": "var(--spacing-none)"
     }
   },
   "pa1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding": "var(--spacing-extra-small)"
     }
   },
   "pa2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding": "var(--spacing-small)"
     }
   },
   "pa3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding": "var(--spacing-medium)"
     }
   },
   "pa4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding": "var(--spacing-large)"
     }
   },
   "pa5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding": "var(--spacing-extra-large)"
     }
   },
   "pa6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding": "var(--spacing-extra-extra-large)"
     }
   },
   "pa7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pl0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-none)"
     }
   },
   "pl1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-extra-small)"
     }
   },
   "pl2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-small)"
     }
   },
   "pl3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-medium)"
     }
   },
   "pl4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-large)"
     }
   },
   "pl5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-extra-large)"
     }
   },
   "pl6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-extra-extra-large)"
     }
   },
   "pl7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pr0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-right": "var(--spacing-none)"
     }
   },
   "pr1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-right": "var(--spacing-extra-small)"
     }
   },
   "pr2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-right": "var(--spacing-small)"
     }
   },
   "pr3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-right": "var(--spacing-medium)"
     }
   },
   "pr4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-right": "var(--spacing-large)"
     }
   },
   "pr5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-right": "var(--spacing-extra-large)"
     }
   },
   "pr6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-right": "var(--spacing-extra-extra-large)"
     }
   },
   "pr7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pb0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "var(--spacing-none)"
     }
   },
   "pb1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "var(--spacing-extra-small)"
     }
   },
   "pb2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "var(--spacing-small)"
     }
   },
   "pb3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "var(--spacing-medium)"
     }
   },
   "pb4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "var(--spacing-large)"
     }
   },
   "pb5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "var(--spacing-extra-large)"
     }
   },
   "pb6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "var(--spacing-extra-extra-large)"
     }
   },
   "pb7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-bottom": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pt0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-none)"
     }
   },
   "pt1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-extra-small)"
     }
   },
   "pt2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-small)"
     }
   },
   "pt3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-medium)"
     }
   },
   "pt4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-large)"
     }
   },
   "pt5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-extra-large)"
     }
   },
   "pt6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-extra-extra-large)"
     }
   },
   "pt7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pv0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-none)",
       "padding-bottom": "var(--spacing-none)"
     }
   },
   "pv1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-extra-small)",
       "padding-bottom": "var(--spacing-extra-small)"
     }
   },
   "pv2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-small)",
       "padding-bottom": "var(--spacing-small)"
     }
   },
   "pv3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-medium)",
       "padding-bottom": "var(--spacing-medium)"
     }
   },
   "pv4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-large)",
       "padding-bottom": "var(--spacing-large)"
     }
   },
   "pv5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-extra-large)",
       "padding-bottom": "var(--spacing-extra-large)"
     }
   },
   "pv6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-extra-extra-large)",
       "padding-bottom": "var(--spacing-extra-extra-large)"
     }
   },
   "pv7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-top": "var(--spacing-extra-extra-extra-large)",
       "padding-bottom": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "ph0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-none)",
       "padding-right": "var(--spacing-none)"
     }
   },
   "ph1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-extra-small)",
       "padding-right": "var(--spacing-extra-small)"
     }
   },
   "ph2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-small)",
       "padding-right": "var(--spacing-small)"
     }
   },
   "ph3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-medium)",
       "padding-right": "var(--spacing-medium)"
     }
   },
   "ph4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-large)",
       "padding-right": "var(--spacing-large)"
     }
   },
   "ph5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-extra-large)",
       "padding-right": "var(--spacing-extra-large)"
     }
   },
   "ph6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-extra-extra-large)",
       "padding-right": "var(--spacing-extra-extra-large)"
     }
   },
   "ph7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "padding-left": "var(--spacing-extra-extra-extra-large)",
       "padding-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "ma0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin": "var(--spacing-none)"
     }
   },
   "ma1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin": "var(--spacing-extra-small)"
     }
   },
   "ma2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin": "var(--spacing-small)"
     }
   },
   "ma3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin": "var(--spacing-medium)"
     }
   },
   "ma4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin": "var(--spacing-large)"
     }
   },
   "ma5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin": "var(--spacing-extra-large)"
     }
   },
   "ma6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin": "var(--spacing-extra-extra-large)"
     }
   },
   "ma7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "ml0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-none)"
     }
   },
   "ml1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-extra-small)"
     }
   },
   "ml2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-small)"
     }
   },
   "ml3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-medium)"
     }
   },
   "ml4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-large)"
     }
   },
   "ml5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-extra-large)"
     }
   },
   "ml6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-extra-extra-large)"
     }
   },
   "ml7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mr0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-right": "var(--spacing-none)"
     }
   },
   "mr1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-right": "var(--spacing-extra-small)"
     }
   },
   "mr2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-right": "var(--spacing-small)"
     }
   },
   "mr3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-right": "var(--spacing-medium)"
     }
   },
   "mr4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-right": "var(--spacing-large)"
     }
   },
   "mr5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-right": "var(--spacing-extra-large)"
     }
   },
   "mr6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-right": "var(--spacing-extra-extra-large)"
     }
   },
   "mr7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mb0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-bottom": "var(--spacing-none)"
     }
   },
   "mb1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-bottom": "var(--spacing-extra-small)"
     }
   },
   "mb2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-bottom": "var(--spacing-small)"
     }
   },
   "mb3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-bottom": "var(--spacing-medium)"
     }
   },
   "mb4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-bottom": "var(--spacing-large)"
     }
   },
   "mb5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-bottom": "var(--spacing-extra-large)"
     }
   },
   "mb6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-bottom": "var(--spacing-extra-extra-large)"
     }
   },
   "mb7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-bottom": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mt0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-none)"
     }
   },
   "mt1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-extra-small)"
     }
   },
   "mt2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-small)"
     }
   },
   "mt3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-medium)"
     }
   },
   "mt4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-large)"
     }
   },
   "mt5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-extra-large)"
     }
   },
   "mt6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-extra-extra-large)"
     }
   },
   "mt7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mv0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-none)",
       "margin-bottom": "var(--spacing-none)"
     }
   },
   "mv1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-extra-small)",
       "margin-bottom": "var(--spacing-extra-small)"
     }
   },
   "mv2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-small)",
       "margin-bottom": "var(--spacing-small)"
     }
   },
   "mv3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-medium)",
       "margin-bottom": "var(--spacing-medium)"
     }
   },
   "mv4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-large)",
       "margin-bottom": "var(--spacing-large)"
     }
   },
   "mv5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-extra-large)",
       "margin-bottom": "var(--spacing-extra-large)"
     }
   },
   "mv6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-extra-extra-large)",
       "margin-bottom": "var(--spacing-extra-extra-large)"
     }
   },
   "mv7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-top": "var(--spacing-extra-extra-extra-large)",
       "margin-bottom": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mh0_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-none)",
       "margin-right": "var(--spacing-none)"
     }
   },
   "mh1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-extra-small)",
       "margin-right": "var(--spacing-extra-small)"
     }
   },
   "mh2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-small)",
       "margin-right": "var(--spacing-small)"
     }
   },
   "mh3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-medium)",
       "margin-right": "var(--spacing-medium)"
     }
   },
   "mh4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-large)",
       "margin-right": "var(--spacing-large)"
     }
   },
   "mh5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-extra-large)",
       "margin-right": "var(--spacing-extra-large)"
     }
   },
   "mh6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-extra-extra-large)",
       "margin-right": "var(--spacing-extra-extra-large)"
     }
   },
   "mh7_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "margin-left": "var(--spacing-extra-extra-extra-large)",
       "margin-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "tl_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "text-align": "left"
     }
   },
   "tr_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "text-align": "right"
     }
   },
   "tc_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "text-align": "center"
     }
   },
   "strike_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "text-decoration": "line-through"
     }
   },
   "underline_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "text-decoration": "underline"
     }
   },
   "no_underline_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "text-decoration": "none"
     }
   },
   "ttc_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "text-transform": "capitalize"
     }
   },
   "ttl_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "text-transform": "lowercase"
     }
   },
   "ttu_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "text-transform": "uppercase"
     }
   },
   "ttn_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "text-transform": "none"
     }
   },
   "f_6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-size": "6rem"
     }
   },
   "f_headline_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-size": "6rem"
     }
   },
   "f_5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-size": "5rem"
     }
   },
   "f_subheadline_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-size": "5rem"
     }
   },
   "f1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-size": "3rem"
     }
   },
   "f2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-size": "2.25rem"
     }
   },
   "f3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-size": "1.5rem"
     }
   },
   "f4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-size": "1.25rem"
     }
   },
   "f5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-size": "1rem"
     }
   },
   "f6_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-size": ".875rem"
     }
   },
   "measure_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "30em"
     }
   },
   "measure_wide_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "34em"
     }
   },
   "measure_narrow_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "max-width": "20em"
     }
   },
   "indent_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "text-indent": "1em",
       "margin-top": "0",
       "margin-bottom": "0"
     }
   },
   "small_caps_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "font-variant": "small-caps"
     }
   },
   "truncate_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "white-space": "nowrap",
       "overflow": "hidden",
       "text-overflow": "ellipsis"
     }
   },
   "v_base_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "vertical-align": "baseline"
     }
   },
   "v_mid_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "vertical-align": "middle"
     }
   },
   "v_top_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "vertical-align": "top"
     }
   },
   "v_btm_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "vertical-align": "bottom"
     }
   },
   "clip_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "position": "fixed !important",
       "_position": "absolute !important",
       "clip": "rect(1px, 1px, 1px, 1px)"
     }
   },
   "ws_normal_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "white-space": "normal"
     }
   },
   "nowrap_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "white-space": "nowrap"
     }
   },
   "pre_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "white-space": "pre"
     }
   },
   "w1_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "1rem"
     }
   },
   "w2_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "2rem"
     }
   },
   "w3_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "4rem"
     }
   },
   "w4_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "8rem"
     }
   },
   "w5_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "16rem"
     }
   },
   "w_10_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "10%"
     }
   },
   "w_20_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "20%"
     }
   },
   "w_25_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "25%"
     }
   },
   "w_30_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "30%"
     }
   },
   "w_33_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "33%"
     }
   },
   "w_34_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "34%"
     }
   },
   "w_40_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "40%"
     }
   },
   "w_50_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "50%"
     }
   },
   "w_60_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "60%"
     }
   },
   "w_70_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "70%"
     }
   },
   "w_75_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "75%"
     }
   },
   "w_80_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "80%"
     }
   },
   "w_90_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "90%"
     }
   },
   "w_100_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "100%"
     }
   },
   "w_third_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "calc(100% / 3)"
     }
   },
   "w_two_thirds_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "calc(100% / 1.5)"
     }
   },
   "w_auto_ns": {
-    "@media screen and (min-width: 48em)": {
+    "@media screen and (min-width: 30em)": {
       "width": "auto"
     }
   },
   "aspect_ratio_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "0",
       "position": "relative"
     }
   },
   "aspect_ratio__16x9_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "56.25%"
     }
   },
   "aspect_ratio__9x16_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "177.77%"
     }
   },
   "aspect_ratio__4x3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "75%"
     }
   },
   "aspect_ratio__3x4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "133.33%"
     }
   },
   "aspect_ratio__6x4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "66.6%"
     }
   },
   "aspect_ratio__4x6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "150%"
     }
   },
   "aspect_ratio__8x5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "62.5%"
     }
   },
   "aspect_ratio__5x8_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "160%"
     }
   },
   "aspect_ratio__7x5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "71.42%"
     }
   },
   "aspect_ratio__5x7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "140%"
     }
   },
   "aspect_ratio__1x1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "100%"
     }
   },
   "aspect_ratio__object_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "position": "absolute",
       "top": "0",
       "right": "0",
@@ -4288,357 +4288,357 @@ module.exports = {
     }
   },
   "bg_center_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "background-repeat": "no-repeat",
       "background-position": "center center"
     }
   },
   "bg_top_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "background-repeat": "no-repeat",
       "background-position": "top center"
     }
   },
   "bg_right_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "background-repeat": "no-repeat",
       "background-position": "center right"
     }
   },
   "bg_bottom_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "background-repeat": "no-repeat",
       "background-position": "bottom center"
     }
   },
   "bg_left_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "background-repeat": "no-repeat",
       "background-position": "center left"
     }
   },
   "cover_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "background-size": "cover"
     }
   },
   "contain_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "background-size": "contain"
     }
   },
   "br0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-radius": "0"
     }
   },
   "br1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-radius": ".125rem"
     }
   },
   "br2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-radius": ".25rem"
     }
   },
   "br3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-radius": ".5rem"
     }
   },
   "br4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-radius": "1rem"
     }
   },
   "br_100_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-radius": "100%"
     }
   },
   "br_pill_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-radius": "9999px"
     }
   },
   "br__bottom_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-top-left-radius": "0",
       "border-top-right-radius": "0"
     }
   },
   "br__top_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-bottom-left-radius": "0",
       "border-bottom-right-radius": "0"
     }
   },
   "br__right_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-top-left-radius": "0",
       "border-bottom-left-radius": "0"
     }
   },
   "br__left_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-top-right-radius": "0",
       "border-bottom-right-radius": "0"
     }
   },
   "b__dotted_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-style": "dotted"
     }
   },
   "b__dashed_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-style": "dashed"
     }
   },
   "b__solid_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-style": "solid"
     }
   },
   "b__none_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-style": "none"
     }
   },
   "bw0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-width": "0"
     }
   },
   "bw1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-width": ".125rem"
     }
   },
   "bw2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-width": ".25rem"
     }
   },
   "bw3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-width": ".5rem"
     }
   },
   "bw4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-width": "1rem"
     }
   },
   "bw5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-width": "2rem"
     }
   },
   "bt_0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-top-width": "0"
     }
   },
   "br_0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-right-width": "0"
     }
   },
   "bb_0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-bottom-width": "0"
     }
   },
   "bl_0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-left-width": "0"
     }
   },
   "ba_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-style": "solid",
       "border-width": "1px"
     }
   },
   "bt_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-top-style": "solid",
       "border-top-width": "1px"
     }
   },
   "br_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-right-style": "solid",
       "border-right-width": "1px"
     }
   },
   "bb_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-bottom-style": "solid",
       "border-bottom-width": "1px"
     }
   },
   "bl_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-left-style": "solid",
       "border-left-width": "1px"
     }
   },
   "bn_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "border-style": "none",
       "border-width": "0"
     }
   },
   "shadow_1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "box-shadow": "0px 0px 4px 2px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "shadow_2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "box-shadow": "0px 0px 8px 2px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "shadow_3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "box-shadow": "2px 2px 4px 2px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "shadow_4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "box-shadow": "2px 2px 8px 0px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "shadow_5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "box-shadow": "4px 4px 8px 0px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "cl_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "clear": "left"
     }
   },
   "cr_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "clear": "right"
     }
   },
   "cb_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "clear": "both"
     }
   },
   "cn_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "clear": "none"
     }
   },
   "top_0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "top": "0"
     }
   },
   "left_0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "left": "0"
     }
   },
   "right_0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "right": "0"
     }
   },
   "bottom_0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "bottom": "0"
     }
   },
   "top_1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "top": "1rem"
     }
   },
   "left_1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "left": "1rem"
     }
   },
   "right_1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "right": "1rem"
     }
   },
   "bottom_1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "bottom": "1rem"
     }
   },
   "top_2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "top": "2rem"
     }
   },
   "left_2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "left": "2rem"
     }
   },
   "right_2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "right": "2rem"
     }
   },
   "bottom_2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "bottom": "2rem"
     }
   },
   "top__1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "top": "-1rem"
     }
   },
   "right__1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "right": "-1rem"
     }
   },
   "bottom__1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "bottom": "-1rem"
     }
   },
   "left__1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "left": "-1rem"
     }
   },
   "top__2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "top": "-2rem"
     }
   },
   "right__2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "right": "-2rem"
     }
   },
   "bottom__2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "bottom": "-2rem"
     }
   },
   "left__2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "left": "-2rem"
     }
   },
   "absolute__fill_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "top": "0",
       "right": "0",
       "bottom": "0",
@@ -4646,1591 +4646,1591 @@ module.exports = {
     }
   },
   "dn_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "display": "none"
     }
   },
   "di_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "display": "inline"
     }
   },
   "db_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "display": "block"
     }
   },
   "dib_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "display": "inline-block"
     }
   },
   "dit_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "display": "inline-table"
     }
   },
   "dt_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "display": "table"
     }
   },
   "dtc_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "display": "table-cell"
     }
   },
   "dt_row_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "display": "table-row"
     }
   },
   "dt_row_group_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "display": "table-row-group"
     }
   },
   "dt_column_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "display": "table-column"
     }
   },
   "dt_column_group_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "display": "table-column-group"
     }
   },
   "dt__fixed_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "table-layout": "fixed",
       "width": "100%"
     }
   },
   "flex_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "display": "flex"
     }
   },
   "inline_flex_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "display": "inline-flex"
     }
   },
   "flex_auto_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "flex": "1 1 auto",
       "min-width": "0",
       "min-height": "0"
     }
   },
   "flex_none_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "flex": "none"
     }
   },
   "flex_column_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "flex-direction": "column"
     }
   },
   "flex_row_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "flex-direction": "row"
     }
   },
   "flex_wrap_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "flex-wrap": "wrap"
     }
   },
   "items_start_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-items": "flex-start"
     }
   },
   "items_end_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-items": "flex-end"
     }
   },
   "items_center_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-items": "center"
     }
   },
   "items_baseline_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-items": "baseline"
     }
   },
   "items_stretch_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-items": "stretch"
     }
   },
   "self_start_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-self": "flex-start"
     }
   },
   "self_end_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-self": "flex-end"
     }
   },
   "self_center_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-self": "center"
     }
   },
   "self_baseline_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-self": "baseline"
     }
   },
   "self_stretch_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-self": "stretch"
     }
   },
   "justify_start_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "justify-content": "flex-start"
     }
   },
   "justify_end_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "justify-content": "flex-end"
     }
   },
   "justify_center_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "justify-content": "center"
     }
   },
   "justify_between_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "justify-content": "space-between"
     }
   },
   "justify_around_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "justify-content": "space-around"
     }
   },
   "content_start_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-content": "flex-start"
     }
   },
   "content_end_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-content": "flex-end"
     }
   },
   "content_center_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-content": "center"
     }
   },
   "content_between_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-content": "space-between"
     }
   },
   "content_around_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-content": "space-around"
     }
   },
   "content_stretch_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "align-content": "stretch"
     }
   },
   "order_0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "order": "0"
     }
   },
   "order_1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "order": "1"
     }
   },
   "order_2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "order": "2"
     }
   },
   "order_3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "order": "3"
     }
   },
   "order_4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "order": "4"
     }
   },
   "order_5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "order": "5"
     }
   },
   "order_6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "order": "6"
     }
   },
   "order_7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "order": "7"
     }
   },
   "order_8_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "order": "8"
     }
   },
   "order_last_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "order": "99999"
     }
   },
   "fl_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "float": "left",
       "_display": "inline"
     }
   },
   "fr_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "float": "right",
       "_display": "inline"
     }
   },
   "fn_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "float": "none"
     }
   },
   "i_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-style": "italic"
     }
   },
   "fs_normal_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-style": "normal"
     }
   },
   "normal_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-weight": "normal"
     }
   },
   "b_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-weight": "bold"
     }
   },
   "fw1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-weight": "100"
     }
   },
   "fw2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-weight": "200"
     }
   },
   "fw3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-weight": "300"
     }
   },
   "fw4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-weight": "400"
     }
   },
   "fw5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-weight": "500"
     }
   },
   "fw6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-weight": "600"
     }
   },
   "fw7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-weight": "700"
     }
   },
   "fw8_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-weight": "800"
     }
   },
   "fw9_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-weight": "900"
     }
   },
   "h1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "1rem"
     }
   },
   "h2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "2rem"
     }
   },
   "h3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "4rem"
     }
   },
   "h4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "8rem"
     }
   },
   "h5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "16rem"
     }
   },
   "h_25_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "25%"
     }
   },
   "h_50_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "50%"
     }
   },
   "h_75_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "75%"
     }
   },
   "h_100_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "100%"
     }
   },
   "vh_25_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "25vh"
     }
   },
   "vh_50_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "50vh"
     }
   },
   "vh_75_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "75vh"
     }
   },
   "vh_100_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "100vh"
     }
   },
   "min_vh_100_m": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "min-height": "100vh"
     }
   },
   "h_auto_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "auto"
     }
   },
   "h_inherit_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "height": "inherit"
     }
   },
   "tracked_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "letter-spacing": ".1em"
     }
   },
   "tracked_tight_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "letter-spacing": "-.05em"
     }
   },
   "tracked_mega_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "letter-spacing": ".25em"
     }
   },
   "lh_solid_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "line-height": "1"
     }
   },
   "lh_title_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "line-height": "1.25"
     }
   },
   "lh_copy_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "line-height": "1.5"
     }
   },
   "mw_100_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "100%"
     }
   },
   "mw1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "1rem"
     }
   },
   "mw2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "2rem"
     }
   },
   "mw3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "4rem"
     }
   },
   "mw4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "8rem"
     }
   },
   "mw5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "16rem"
     }
   },
   "mw6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "32rem"
     }
   },
   "mw7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "48rem"
     }
   },
   "mw8_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "64rem"
     }
   },
   "mw9_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "96rem"
     }
   },
   "mw_none_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "none"
     }
   },
   "outline_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "outline": "1px solid"
     }
   },
   "outline_transparent_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "outline": "1px solid transparent"
     }
   },
   "outline_0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "outline": "0"
     }
   },
   "outline_l": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "outline": "1px solid"
     }
   },
   "outline_transparent_l": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "outline": "1px solid transparent"
     }
   },
   "outline_0_l": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "outline": "0"
     }
   },
   "overflow_visible_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "overflow": "visible"
     }
   },
   "overflow_hidden_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "overflow": "hidden"
     }
   },
   "overflow_scroll_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "overflow": "scroll"
     }
   },
   "overflow_auto_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "overflow": "auto"
     }
   },
   "overflow_x_visible_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "overflow-x": "visible"
     }
   },
   "overflow_x_hidden_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "overflow-x": "hidden"
     }
   },
   "overflow_x_scroll_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "overflow-x": "scroll"
     }
   },
   "overflow_x_auto_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "overflow-x": "auto"
     }
   },
   "overflow_y_visible_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "overflow-y": "visible"
     }
   },
   "overflow_y_hidden_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "overflow-y": "hidden"
     }
   },
   "overflow_y_scroll_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "overflow-y": "scroll"
     }
   },
   "overflow_y_auto_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "overflow-y": "auto"
     }
   },
   "static_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "position": "static"
     }
   },
   "relative_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "position": "relative"
     }
   },
   "absolute_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "position": "absolute"
     }
   },
   "fixed_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "position": "fixed"
     }
   },
   "rotate_45_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "transform": "rotate(45deg)"
     }
   },
   "rotate_90_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "transform": "rotate(90deg)"
     }
   },
   "rotate_135_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "transform": "rotate(135deg)"
     }
   },
   "rotate_180_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "transform": "rotate(180deg)"
     }
   },
   "rotate_225_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "transform": "rotate(225deg)"
     }
   },
   "rotate_270_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "transform": "rotate(270deg)"
     }
   },
   "rotate_315_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "transform": "rotate(315deg)"
     }
   },
   "pa0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding": "var(--spacing-none)"
     }
   },
   "pa1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding": "var(--spacing-extra-small)"
     }
   },
   "pa2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding": "var(--spacing-small)"
     }
   },
   "pa3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding": "var(--spacing-medium)"
     }
   },
   "pa4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding": "var(--spacing-large)"
     }
   },
   "pa5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding": "var(--spacing-extra-large)"
     }
   },
   "pa6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding": "var(--spacing-extra-extra-large)"
     }
   },
   "pa7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pl0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-none)"
     }
   },
   "pl1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-extra-small)"
     }
   },
   "pl2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-small)"
     }
   },
   "pl3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-medium)"
     }
   },
   "pl4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-large)"
     }
   },
   "pl5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-extra-large)"
     }
   },
   "pl6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-extra-extra-large)"
     }
   },
   "pl7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pr0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-right": "var(--spacing-none)"
     }
   },
   "pr1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-right": "var(--spacing-extra-small)"
     }
   },
   "pr2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-right": "var(--spacing-small)"
     }
   },
   "pr3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-right": "var(--spacing-medium)"
     }
   },
   "pr4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-right": "var(--spacing-large)"
     }
   },
   "pr5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-right": "var(--spacing-extra-large)"
     }
   },
   "pr6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-right": "var(--spacing-extra-extra-large)"
     }
   },
   "pr7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pb0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "var(--spacing-none)"
     }
   },
   "pb1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "var(--spacing-extra-small)"
     }
   },
   "pb2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "var(--spacing-small)"
     }
   },
   "pb3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "var(--spacing-medium)"
     }
   },
   "pb4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "var(--spacing-large)"
     }
   },
   "pb5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "var(--spacing-extra-large)"
     }
   },
   "pb6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "var(--spacing-extra-extra-large)"
     }
   },
   "pb7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-bottom": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pt0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-none)"
     }
   },
   "pt1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-extra-small)"
     }
   },
   "pt2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-small)"
     }
   },
   "pt3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-medium)"
     }
   },
   "pt4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-large)"
     }
   },
   "pt5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-extra-large)"
     }
   },
   "pt6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-extra-extra-large)"
     }
   },
   "pt7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pv0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-none)",
       "padding-bottom": "var(--spacing-none)"
     }
   },
   "pv1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-extra-small)",
       "padding-bottom": "var(--spacing-extra-small)"
     }
   },
   "pv2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-small)",
       "padding-bottom": "var(--spacing-small)"
     }
   },
   "pv3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-medium)",
       "padding-bottom": "var(--spacing-medium)"
     }
   },
   "pv4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-large)",
       "padding-bottom": "var(--spacing-large)"
     }
   },
   "pv5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-extra-large)",
       "padding-bottom": "var(--spacing-extra-large)"
     }
   },
   "pv6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-extra-extra-large)",
       "padding-bottom": "var(--spacing-extra-extra-large)"
     }
   },
   "pv7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-top": "var(--spacing-extra-extra-extra-large)",
       "padding-bottom": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "ph0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-none)",
       "padding-right": "var(--spacing-none)"
     }
   },
   "ph1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-extra-small)",
       "padding-right": "var(--spacing-extra-small)"
     }
   },
   "ph2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-small)",
       "padding-right": "var(--spacing-small)"
     }
   },
   "ph3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-medium)",
       "padding-right": "var(--spacing-medium)"
     }
   },
   "ph4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-large)",
       "padding-right": "var(--spacing-large)"
     }
   },
   "ph5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-extra-large)",
       "padding-right": "var(--spacing-extra-large)"
     }
   },
   "ph6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-extra-extra-large)",
       "padding-right": "var(--spacing-extra-extra-large)"
     }
   },
   "ph7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "padding-left": "var(--spacing-extra-extra-extra-large)",
       "padding-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "ma0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin": "var(--spacing-none)"
     }
   },
   "ma1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin": "var(--spacing-extra-small)"
     }
   },
   "ma2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin": "var(--spacing-small)"
     }
   },
   "ma3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin": "var(--spacing-medium)"
     }
   },
   "ma4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin": "var(--spacing-large)"
     }
   },
   "ma5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin": "var(--spacing-extra-large)"
     }
   },
   "ma6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin": "var(--spacing-extra-extra-large)"
     }
   },
   "ma7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "ml0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-none)"
     }
   },
   "ml1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-extra-small)"
     }
   },
   "ml2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-small)"
     }
   },
   "ml3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-medium)"
     }
   },
   "ml4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-large)"
     }
   },
   "ml5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-extra-large)"
     }
   },
   "ml6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-extra-extra-large)"
     }
   },
   "ml7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mr0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-right": "var(--spacing-none)"
     }
   },
   "mr1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-right": "var(--spacing-extra-small)"
     }
   },
   "mr2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-right": "var(--spacing-small)"
     }
   },
   "mr3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-right": "var(--spacing-medium)"
     }
   },
   "mr4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-right": "var(--spacing-large)"
     }
   },
   "mr5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-right": "var(--spacing-extra-large)"
     }
   },
   "mr6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-right": "var(--spacing-extra-extra-large)"
     }
   },
   "mr7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mb0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-bottom": "var(--spacing-none)"
     }
   },
   "mb1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-bottom": "var(--spacing-extra-small)"
     }
   },
   "mb2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-bottom": "var(--spacing-small)"
     }
   },
   "mb3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-bottom": "var(--spacing-medium)"
     }
   },
   "mb4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-bottom": "var(--spacing-large)"
     }
   },
   "mb5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-bottom": "var(--spacing-extra-large)"
     }
   },
   "mb6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-bottom": "var(--spacing-extra-extra-large)"
     }
   },
   "mb7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-bottom": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mt0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-none)"
     }
   },
   "mt1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-extra-small)"
     }
   },
   "mt2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-small)"
     }
   },
   "mt3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-medium)"
     }
   },
   "mt4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-large)"
     }
   },
   "mt5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-extra-large)"
     }
   },
   "mt6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-extra-extra-large)"
     }
   },
   "mt7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mv0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-none)",
       "margin-bottom": "var(--spacing-none)"
     }
   },
   "mv1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-extra-small)",
       "margin-bottom": "var(--spacing-extra-small)"
     }
   },
   "mv2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-small)",
       "margin-bottom": "var(--spacing-small)"
     }
   },
   "mv3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-medium)",
       "margin-bottom": "var(--spacing-medium)"
     }
   },
   "mv4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-large)",
       "margin-bottom": "var(--spacing-large)"
     }
   },
   "mv5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-extra-large)",
       "margin-bottom": "var(--spacing-extra-large)"
     }
   },
   "mv6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-extra-extra-large)",
       "margin-bottom": "var(--spacing-extra-extra-large)"
     }
   },
   "mv7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-top": "var(--spacing-extra-extra-extra-large)",
       "margin-bottom": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mh0_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-none)",
       "margin-right": "var(--spacing-none)"
     }
   },
   "mh1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-extra-small)",
       "margin-right": "var(--spacing-extra-small)"
     }
   },
   "mh2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-small)",
       "margin-right": "var(--spacing-small)"
     }
   },
   "mh3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-medium)",
       "margin-right": "var(--spacing-medium)"
     }
   },
   "mh4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-large)",
       "margin-right": "var(--spacing-large)"
     }
   },
   "mh5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-extra-large)",
       "margin-right": "var(--spacing-extra-large)"
     }
   },
   "mh6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-extra-extra-large)",
       "margin-right": "var(--spacing-extra-extra-large)"
     }
   },
   "mh7_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "margin-left": "var(--spacing-extra-extra-extra-large)",
       "margin-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "tl_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "text-align": "left"
     }
   },
   "tr_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "text-align": "right"
     }
   },
   "tc_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "text-align": "center"
     }
   },
   "strike_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "text-decoration": "line-through"
     }
   },
   "underline_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "text-decoration": "underline"
     }
   },
   "no_underline_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "text-decoration": "none"
     }
   },
   "ttc_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "text-transform": "capitalize"
     }
   },
   "ttl_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "text-transform": "lowercase"
     }
   },
   "ttu_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "text-transform": "uppercase"
     }
   },
   "ttn_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "text-transform": "none"
     }
   },
   "f_6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-size": "6rem"
     }
   },
   "f_headline_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-size": "6rem"
     }
   },
   "f_5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-size": "5rem"
     }
   },
   "f_subheadline_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-size": "5rem"
     }
   },
   "f1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-size": "3rem"
     }
   },
   "f2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-size": "2.25rem"
     }
   },
   "f3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-size": "1.5rem"
     }
   },
   "f4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-size": "1.25rem"
     }
   },
   "f5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-size": "1rem"
     }
   },
   "f6_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-size": ".875rem"
     }
   },
   "measure_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "30em"
     }
   },
   "measure_wide_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "34em"
     }
   },
   "measure_narrow_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "max-width": "20em"
     }
   },
   "indent_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "text-indent": "1em",
       "margin-top": "0",
       "margin-bottom": "0"
     }
   },
   "small_caps_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "font-variant": "small-caps"
     }
   },
   "truncate_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "white-space": "nowrap",
       "overflow": "hidden",
       "text-overflow": "ellipsis"
     }
   },
   "v_base_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "vertical-align": "baseline"
     }
   },
   "v_mid_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "vertical-align": "middle"
     }
   },
   "v_top_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "vertical-align": "top"
     }
   },
   "v_btm_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "vertical-align": "bottom"
     }
   },
   "clip_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "position": "fixed !important",
       "_position": "absolute !important",
       "clip": "rect(1px, 1px, 1px, 1px)"
     }
   },
   "ws_normal_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "white-space": "normal"
     }
   },
   "nowrap_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "white-space": "nowrap"
     }
   },
   "pre_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "white-space": "pre"
     }
   },
   "w1_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "1rem"
     }
   },
   "w2_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "2rem"
     }
   },
   "w3_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "4rem"
     }
   },
   "w4_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "8rem"
     }
   },
   "w5_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "16rem"
     }
   },
   "w_10_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "10%"
     }
   },
   "w_20_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "20%"
     }
   },
   "w_25_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "25%"
     }
   },
   "w_30_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "30%"
     }
   },
   "w_33_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "33%"
     }
   },
   "w_34_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "34%"
     }
   },
   "w_40_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "40%"
     }
   },
   "w_50_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "50%"
     }
   },
   "w_60_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "60%"
     }
   },
   "w_70_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "70%"
     }
   },
   "w_75_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "75%"
     }
   },
   "w_80_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "80%"
     }
   },
   "w_90_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "90%"
     }
   },
   "w_100_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "100%"
     }
   },
   "w_third_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "calc(100% / 3)"
     }
   },
   "w_two_thirds_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "calc(100% / 1.5)"
     }
   },
   "w_auto_m": {
-    "@media screen and (min-width: 48em) and (max-width: 64em)": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "width": "auto"
     }
   },
   "aspect_ratio_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "0",
       "position": "relative"
     }
   },
   "aspect_ratio__16x9_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "56.25%"
     }
   },
   "aspect_ratio__9x16_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "177.77%"
     }
   },
   "aspect_ratio__4x3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "75%"
     }
   },
   "aspect_ratio__3x4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "133.33%"
     }
   },
   "aspect_ratio__6x4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "66.6%"
     }
   },
   "aspect_ratio__4x6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "150%"
     }
   },
   "aspect_ratio__8x5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "62.5%"
     }
   },
   "aspect_ratio__5x8_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "160%"
     }
   },
   "aspect_ratio__7x5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "71.42%"
     }
   },
   "aspect_ratio__5x7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "140%"
     }
   },
   "aspect_ratio__1x1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "100%"
     }
   },
   "aspect_ratio__object_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "position": "absolute",
       "top": "0",
       "right": "0",
@@ -6242,357 +6242,357 @@ module.exports = {
     }
   },
   "bg_center_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "background-repeat": "no-repeat",
       "background-position": "center center"
     }
   },
   "bg_top_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "background-repeat": "no-repeat",
       "background-position": "top center"
     }
   },
   "bg_right_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "background-repeat": "no-repeat",
       "background-position": "center right"
     }
   },
   "bg_bottom_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "background-repeat": "no-repeat",
       "background-position": "bottom center"
     }
   },
   "bg_left_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "background-repeat": "no-repeat",
       "background-position": "center left"
     }
   },
   "cover_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "background-size": "cover"
     }
   },
   "contain_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "background-size": "contain"
     }
   },
   "br0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-radius": "0"
     }
   },
   "br1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-radius": ".125rem"
     }
   },
   "br2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-radius": ".25rem"
     }
   },
   "br3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-radius": ".5rem"
     }
   },
   "br4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-radius": "1rem"
     }
   },
   "br_100_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-radius": "100%"
     }
   },
   "br_pill_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-radius": "9999px"
     }
   },
   "br__bottom_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-top-left-radius": "0",
       "border-top-right-radius": "0"
     }
   },
   "br__top_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-bottom-left-radius": "0",
       "border-bottom-right-radius": "0"
     }
   },
   "br__right_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-top-left-radius": "0",
       "border-bottom-left-radius": "0"
     }
   },
   "br__left_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-top-right-radius": "0",
       "border-bottom-right-radius": "0"
     }
   },
   "b__dotted_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-style": "dotted"
     }
   },
   "b__dashed_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-style": "dashed"
     }
   },
   "b__solid_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-style": "solid"
     }
   },
   "b__none_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-style": "none"
     }
   },
   "bw0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-width": "0"
     }
   },
   "bw1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-width": ".125rem"
     }
   },
   "bw2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-width": ".25rem"
     }
   },
   "bw3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-width": ".5rem"
     }
   },
   "bw4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-width": "1rem"
     }
   },
   "bw5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-width": "2rem"
     }
   },
   "bt_0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-top-width": "0"
     }
   },
   "br_0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-right-width": "0"
     }
   },
   "bb_0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-bottom-width": "0"
     }
   },
   "bl_0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-left-width": "0"
     }
   },
   "ba_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-style": "solid",
       "border-width": "1px"
     }
   },
   "bt_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-top-style": "solid",
       "border-top-width": "1px"
     }
   },
   "br_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-right-style": "solid",
       "border-right-width": "1px"
     }
   },
   "bb_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-bottom-style": "solid",
       "border-bottom-width": "1px"
     }
   },
   "bl_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-left-style": "solid",
       "border-left-width": "1px"
     }
   },
   "bn_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "border-style": "none",
       "border-width": "0"
     }
   },
   "shadow_1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "box-shadow": "0px 0px 4px 2px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "shadow_2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "box-shadow": "0px 0px 8px 2px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "shadow_3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "box-shadow": "2px 2px 4px 2px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "shadow_4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "box-shadow": "2px 2px 8px 0px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "shadow_5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "box-shadow": "4px 4px 8px 0px rgba( 0, 0, 0, 0.2 )"
     }
   },
   "cl_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "clear": "left"
     }
   },
   "cr_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "clear": "right"
     }
   },
   "cb_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "clear": "both"
     }
   },
   "cn_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "clear": "none"
     }
   },
   "top_0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "top": "0"
     }
   },
   "left_0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "left": "0"
     }
   },
   "right_0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "right": "0"
     }
   },
   "bottom_0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "bottom": "0"
     }
   },
   "top_1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "top": "1rem"
     }
   },
   "left_1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "left": "1rem"
     }
   },
   "right_1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "right": "1rem"
     }
   },
   "bottom_1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "bottom": "1rem"
     }
   },
   "top_2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "top": "2rem"
     }
   },
   "left_2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "left": "2rem"
     }
   },
   "right_2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "right": "2rem"
     }
   },
   "bottom_2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "bottom": "2rem"
     }
   },
   "top__1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "top": "-1rem"
     }
   },
   "right__1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "right": "-1rem"
     }
   },
   "bottom__1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "bottom": "-1rem"
     }
   },
   "left__1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "left": "-1rem"
     }
   },
   "top__2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "top": "-2rem"
     }
   },
   "right__2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "right": "-2rem"
     }
   },
   "bottom__2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "bottom": "-2rem"
     }
   },
   "left__2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "left": "-2rem"
     }
   },
   "absolute__fill_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "top": "0",
       "right": "0",
       "bottom": "0",
@@ -6600,1495 +6600,1495 @@ module.exports = {
     }
   },
   "dn_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "display": "none"
     }
   },
   "di_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "display": "inline"
     }
   },
   "db_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "display": "block"
     }
   },
   "dib_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "display": "inline-block"
     }
   },
   "dit_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "display": "inline-table"
     }
   },
   "dt_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "display": "table"
     }
   },
   "dtc_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "display": "table-cell"
     }
   },
   "dt_row_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "display": "table-row"
     }
   },
   "dt_row_group_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "display": "table-row-group"
     }
   },
   "dt_column_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "display": "table-column"
     }
   },
   "dt_column_group_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "display": "table-column-group"
     }
   },
   "dt__fixed_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "table-layout": "fixed",
       "width": "100%"
     }
   },
   "flex_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "display": "flex"
     }
   },
   "inline_flex_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "display": "inline-flex"
     }
   },
   "flex_auto_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "flex": "1 1 auto",
       "min-width": "0",
       "min-height": "0"
     }
   },
   "flex_none_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "flex": "none"
     }
   },
   "flex_column_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "flex-direction": "column"
     }
   },
   "flex_row_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "flex-direction": "row"
     }
   },
   "flex_wrap_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "flex-wrap": "wrap"
     }
   },
   "items_start_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-items": "flex-start"
     }
   },
   "items_end_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-items": "flex-end"
     }
   },
   "items_center_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-items": "center"
     }
   },
   "items_baseline_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-items": "baseline"
     }
   },
   "items_stretch_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-items": "stretch"
     }
   },
   "self_start_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-self": "flex-start"
     }
   },
   "self_end_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-self": "flex-end"
     }
   },
   "self_center_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-self": "center"
     }
   },
   "self_baseline_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-self": "baseline"
     }
   },
   "self_stretch_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-self": "stretch"
     }
   },
   "justify_start_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "justify-content": "flex-start"
     }
   },
   "justify_end_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "justify-content": "flex-end"
     }
   },
   "justify_center_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "justify-content": "center"
     }
   },
   "justify_between_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "justify-content": "space-between"
     }
   },
   "justify_around_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "justify-content": "space-around"
     }
   },
   "content_start_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-content": "flex-start"
     }
   },
   "content_end_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-content": "flex-end"
     }
   },
   "content_center_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-content": "center"
     }
   },
   "content_between_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-content": "space-between"
     }
   },
   "content_around_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-content": "space-around"
     }
   },
   "content_stretch_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "align-content": "stretch"
     }
   },
   "order_0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "order": "0"
     }
   },
   "order_1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "order": "1"
     }
   },
   "order_2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "order": "2"
     }
   },
   "order_3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "order": "3"
     }
   },
   "order_4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "order": "4"
     }
   },
   "order_5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "order": "5"
     }
   },
   "order_6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "order": "6"
     }
   },
   "order_7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "order": "7"
     }
   },
   "order_8_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "order": "8"
     }
   },
   "order_last_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "order": "99999"
     }
   },
   "fl_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "float": "left",
       "_display": "inline"
     }
   },
   "fr_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "float": "right",
       "_display": "inline"
     }
   },
   "fn_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "float": "none"
     }
   },
   "i_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-style": "italic"
     }
   },
   "fs_normal_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-style": "normal"
     }
   },
   "normal_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-weight": "normal"
     }
   },
   "b_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-weight": "bold"
     }
   },
   "fw1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-weight": "100"
     }
   },
   "fw2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-weight": "200"
     }
   },
   "fw3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-weight": "300"
     }
   },
   "fw4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-weight": "400"
     }
   },
   "fw5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-weight": "500"
     }
   },
   "fw6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-weight": "600"
     }
   },
   "fw7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-weight": "700"
     }
   },
   "fw8_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-weight": "800"
     }
   },
   "fw9_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-weight": "900"
     }
   },
   "h1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "1rem"
     }
   },
   "h2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "2rem"
     }
   },
   "h3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "4rem"
     }
   },
   "h4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "8rem"
     }
   },
   "h5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "16rem"
     }
   },
   "h_25_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "25%"
     }
   },
   "h_50_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "50%"
     }
   },
   "h_75_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "75%"
     }
   },
   "h_100_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "100%"
     }
   },
   "min_h_100_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "min-height": "100%"
     }
   },
   "vh_25_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "25vh"
     }
   },
   "vh_50_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "50vh"
     }
   },
   "vh_75_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "75vh"
     }
   },
   "vh_100_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "100vh"
     }
   },
   "h_auto_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "auto"
     }
   },
   "h_inherit_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "height": "inherit"
     }
   },
   "tracked_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "letter-spacing": ".1em"
     }
   },
   "tracked_tight_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "letter-spacing": "-.05em"
     }
   },
   "tracked_mega_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "letter-spacing": ".25em"
     }
   },
   "lh_solid_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "line-height": "1"
     }
   },
   "lh_title_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "line-height": "1.25"
     }
   },
   "lh_copy_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "line-height": "1.5"
     }
   },
   "mw_100_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "100%"
     }
   },
   "mw1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "1rem"
     }
   },
   "mw2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "2rem"
     }
   },
   "mw3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "4rem"
     }
   },
   "mw4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "8rem"
     }
   },
   "mw5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "16rem"
     }
   },
   "mw6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "32rem"
     }
   },
   "mw7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "48rem"
     }
   },
   "mw8_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "64rem"
     }
   },
   "mw9_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "96rem"
     }
   },
   "mw_none_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "none"
     }
   },
   "overflow_visible_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "overflow": "visible"
     }
   },
   "overflow_hidden_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "overflow": "hidden"
     }
   },
   "overflow_scroll_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "overflow": "scroll"
     }
   },
   "overflow_auto_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "overflow": "auto"
     }
   },
   "overflow_x_visible_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "overflow-x": "visible"
     }
   },
   "overflow_x_hidden_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "overflow-x": "hidden"
     }
   },
   "overflow_x_scroll_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "overflow-x": "scroll"
     }
   },
   "overflow_x_auto_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "overflow-x": "auto"
     }
   },
   "overflow_y_visible_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "overflow-y": "visible"
     }
   },
   "overflow_y_hidden_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "overflow-y": "hidden"
     }
   },
   "overflow_y_scroll_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "overflow-y": "scroll"
     }
   },
   "overflow_y_auto_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "overflow-y": "auto"
     }
   },
   "static_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "position": "static"
     }
   },
   "relative_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "position": "relative"
     }
   },
   "absolute_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "position": "absolute"
     }
   },
   "fixed_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "position": "fixed"
     }
   },
   "rotate_45_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "transform": "rotate(45deg)"
     }
   },
   "rotate_90_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "transform": "rotate(90deg)"
     }
   },
   "rotate_135_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "transform": "rotate(135deg)"
     }
   },
   "rotate_180_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "transform": "rotate(180deg)"
     }
   },
   "rotate_225_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "transform": "rotate(225deg)"
     }
   },
   "rotate_270_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "transform": "rotate(270deg)"
     }
   },
   "rotate_315_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "transform": "rotate(315deg)"
     }
   },
   "pa0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding": "var(--spacing-none)"
     }
   },
   "pa1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding": "var(--spacing-extra-small)"
     }
   },
   "pa2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding": "var(--spacing-small)"
     }
   },
   "pa3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding": "var(--spacing-medium)"
     }
   },
   "pa4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding": "var(--spacing-large)"
     }
   },
   "pa5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding": "var(--spacing-extra-large)"
     }
   },
   "pa6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding": "var(--spacing-extra-extra-large)"
     }
   },
   "pa7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pl0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-none)"
     }
   },
   "pl1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-extra-small)"
     }
   },
   "pl2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-small)"
     }
   },
   "pl3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-medium)"
     }
   },
   "pl4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-large)"
     }
   },
   "pl5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-extra-large)"
     }
   },
   "pl6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-extra-extra-large)"
     }
   },
   "pl7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pr0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-right": "var(--spacing-none)"
     }
   },
   "pr1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-right": "var(--spacing-extra-small)"
     }
   },
   "pr2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-right": "var(--spacing-small)"
     }
   },
   "pr3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-right": "var(--spacing-medium)"
     }
   },
   "pr4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-right": "var(--spacing-large)"
     }
   },
   "pr5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-right": "var(--spacing-extra-large)"
     }
   },
   "pr6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-right": "var(--spacing-extra-extra-large)"
     }
   },
   "pr7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pb0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "var(--spacing-none)"
     }
   },
   "pb1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "var(--spacing-extra-small)"
     }
   },
   "pb2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "var(--spacing-small)"
     }
   },
   "pb3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "var(--spacing-medium)"
     }
   },
   "pb4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "var(--spacing-large)"
     }
   },
   "pb5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "var(--spacing-extra-large)"
     }
   },
   "pb6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "var(--spacing-extra-extra-large)"
     }
   },
   "pb7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-bottom": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pt0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-none)"
     }
   },
   "pt1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-extra-small)"
     }
   },
   "pt2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-small)"
     }
   },
   "pt3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-medium)"
     }
   },
   "pt4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-large)"
     }
   },
   "pt5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-extra-large)"
     }
   },
   "pt6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-extra-extra-large)"
     }
   },
   "pt7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "pv0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-none)",
       "padding-bottom": "var(--spacing-none)"
     }
   },
   "pv1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-extra-small)",
       "padding-bottom": "var(--spacing-extra-small)"
     }
   },
   "pv2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-small)",
       "padding-bottom": "var(--spacing-small)"
     }
   },
   "pv3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-medium)",
       "padding-bottom": "var(--spacing-medium)"
     }
   },
   "pv4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-large)",
       "padding-bottom": "var(--spacing-large)"
     }
   },
   "pv5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-extra-large)",
       "padding-bottom": "var(--spacing-extra-large)"
     }
   },
   "pv6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-extra-extra-large)",
       "padding-bottom": "var(--spacing-extra-extra-large)"
     }
   },
   "pv7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-top": "var(--spacing-extra-extra-extra-large)",
       "padding-bottom": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "ph0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-none)",
       "padding-right": "var(--spacing-none)"
     }
   },
   "ph1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-extra-small)",
       "padding-right": "var(--spacing-extra-small)"
     }
   },
   "ph2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-small)",
       "padding-right": "var(--spacing-small)"
     }
   },
   "ph3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-medium)",
       "padding-right": "var(--spacing-medium)"
     }
   },
   "ph4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-large)",
       "padding-right": "var(--spacing-large)"
     }
   },
   "ph5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-extra-large)",
       "padding-right": "var(--spacing-extra-large)"
     }
   },
   "ph6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-extra-extra-large)",
       "padding-right": "var(--spacing-extra-extra-large)"
     }
   },
   "ph7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "padding-left": "var(--spacing-extra-extra-extra-large)",
       "padding-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "ma0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin": "var(--spacing-none)"
     }
   },
   "ma1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin": "var(--spacing-extra-small)"
     }
   },
   "ma2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin": "var(--spacing-small)"
     }
   },
   "ma3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin": "var(--spacing-medium)"
     }
   },
   "ma4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin": "var(--spacing-large)"
     }
   },
   "ma5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin": "var(--spacing-extra-large)"
     }
   },
   "ma6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin": "var(--spacing-extra-extra-large)"
     }
   },
   "ma7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "ml0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-none)"
     }
   },
   "ml1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-extra-small)"
     }
   },
   "ml2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-small)"
     }
   },
   "ml3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-medium)"
     }
   },
   "ml4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-large)"
     }
   },
   "ml5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-extra-large)"
     }
   },
   "ml6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-extra-extra-large)"
     }
   },
   "ml7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mr0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-right": "var(--spacing-none)"
     }
   },
   "mr1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-right": "var(--spacing-extra-small)"
     }
   },
   "mr2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-right": "var(--spacing-small)"
     }
   },
   "mr3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-right": "var(--spacing-medium)"
     }
   },
   "mr4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-right": "var(--spacing-large)"
     }
   },
   "mr5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-right": "var(--spacing-extra-large)"
     }
   },
   "mr6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-right": "var(--spacing-extra-extra-large)"
     }
   },
   "mr7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mb0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-bottom": "var(--spacing-none)"
     }
   },
   "mb1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-bottom": "var(--spacing-extra-small)"
     }
   },
   "mb2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-bottom": "var(--spacing-small)"
     }
   },
   "mb3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-bottom": "var(--spacing-medium)"
     }
   },
   "mb4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-bottom": "var(--spacing-large)"
     }
   },
   "mb5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-bottom": "var(--spacing-extra-large)"
     }
   },
   "mb6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-bottom": "var(--spacing-extra-extra-large)"
     }
   },
   "mb7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-bottom": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mt0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-none)"
     }
   },
   "mt1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-extra-small)"
     }
   },
   "mt2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-small)"
     }
   },
   "mt3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-medium)"
     }
   },
   "mt4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-large)"
     }
   },
   "mt5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-extra-large)"
     }
   },
   "mt6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-extra-extra-large)"
     }
   },
   "mt7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mv0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-none)",
       "margin-bottom": "var(--spacing-none)"
     }
   },
   "mv1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-extra-small)",
       "margin-bottom": "var(--spacing-extra-small)"
     }
   },
   "mv2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-small)",
       "margin-bottom": "var(--spacing-small)"
     }
   },
   "mv3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-medium)",
       "margin-bottom": "var(--spacing-medium)"
     }
   },
   "mv4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-large)",
       "margin-bottom": "var(--spacing-large)"
     }
   },
   "mv5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-extra-large)",
       "margin-bottom": "var(--spacing-extra-large)"
     }
   },
   "mv6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-extra-extra-large)",
       "margin-bottom": "var(--spacing-extra-extra-large)"
     }
   },
   "mv7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-top": "var(--spacing-extra-extra-extra-large)",
       "margin-bottom": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "mh0_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-none)",
       "margin-right": "var(--spacing-none)"
     }
   },
   "mh1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-extra-small)",
       "margin-right": "var(--spacing-extra-small)"
     }
   },
   "mh2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-small)",
       "margin-right": "var(--spacing-small)"
     }
   },
   "mh3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-medium)",
       "margin-right": "var(--spacing-medium)"
     }
   },
   "mh4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-large)",
       "margin-right": "var(--spacing-large)"
     }
   },
   "mh5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-extra-large)",
       "margin-right": "var(--spacing-extra-large)"
     }
   },
   "mh6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-extra-extra-large)",
       "margin-right": "var(--spacing-extra-extra-large)"
     }
   },
   "mh7_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "margin-left": "var(--spacing-extra-extra-extra-large)",
       "margin-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
   "tl_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "text-align": "left"
     }
   },
   "tr_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "text-align": "right"
     }
   },
   "tc_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "text-align": "center"
     }
   },
   "strike_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "text-decoration": "line-through"
     }
   },
   "underline_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "text-decoration": "underline"
     }
   },
   "no_underline_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "text-decoration": "none"
     }
   },
   "ttc_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "text-transform": "capitalize"
     }
   },
   "ttl_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "text-transform": "lowercase"
     }
   },
   "ttu_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "text-transform": "uppercase"
     }
   },
   "ttn_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "text-transform": "none"
     }
   },
   "f_6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-size": "6rem"
     }
   },
   "f_headline_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-size": "6rem"
     }
   },
   "f_5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-size": "5rem"
     }
   },
   "f_subheadline_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-size": "5rem"
     }
   },
   "f1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-size": "3rem"
     }
   },
   "f2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-size": "2.25rem"
     }
   },
   "f3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-size": "1.5rem"
     }
   },
   "f4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-size": "1.25rem"
     }
   },
   "f5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-size": "1rem"
     }
   },
   "f6_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-size": ".875rem"
     }
   },
   "measure_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "30em"
     }
   },
   "measure_wide_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "34em"
     }
   },
   "measure_narrow_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "max-width": "20em"
     }
   },
   "indent_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "text-indent": "1em",
       "margin-top": "0",
       "margin-bottom": "0"
     }
   },
   "small_caps_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "font-variant": "small-caps"
     }
   },
   "truncate_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "white-space": "nowrap",
       "overflow": "hidden",
       "text-overflow": "ellipsis"
     }
   },
   "v_base_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "vertical-align": "baseline"
     }
   },
   "v_mid_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "vertical-align": "middle"
     }
   },
   "v_top_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "vertical-align": "top"
     }
   },
   "v_btm_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "vertical-align": "bottom"
     }
   },
   "clip_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "position": "fixed !important",
       "_position": "absolute !important",
       "clip": "rect(1px, 1px, 1px, 1px)"
     }
   },
   "ws_normal_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "white-space": "normal"
     }
   },
   "nowrap_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "white-space": "nowrap"
     }
   },
   "pre_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "white-space": "pre"
     }
   },
   "w1_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "1rem"
     }
   },
   "w2_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "2rem"
     }
   },
   "w3_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "4rem"
     }
   },
   "w4_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "8rem"
     }
   },
   "w5_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "16rem"
     }
   },
   "w_10_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "10%"
     }
   },
   "w_20_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "20%"
     }
   },
   "w_25_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "25%"
     }
   },
   "w_30_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "30%"
     }
   },
   "w_33_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "33%"
     }
   },
   "w_34_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "34%"
     }
   },
   "w_40_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "40%"
     }
   },
   "w_50_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "50%"
     }
   },
   "w_60_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "60%"
     }
   },
   "w_70_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "70%"
     }
   },
   "w_75_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "75%"
     }
   },
   "w_80_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "80%"
     }
   },
   "w_90_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "90%"
     }
   },
   "w_100_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "100%"
     }
   },
   "w_third_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "calc(100% / 3)"
     }
   },
   "w_two_thirds_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "calc(100% / 1.5)"
     }
   },
   "w_auto_l": {
-    "@media screen and (min-width: 64em)": {
+    "@media screen and (min-width: 60em)": {
       "width": "auto"
     }
   },


### PR DESCRIPTION
I've updated the generate.js and index.js files to reflect the new @media query breakpoints in the latest version of Tachyons.

@media (--breakpoint-not-small)': '@media screen and (min-width: 30em)
@media screen and (min-width: 30em) and (max-width: 60em)
@media screen and (min-width: 60em)