### PR TITLE
Removed tachyons-modules

### DIFF
--- a/generate.js
+++ b/generate.js
@@ -2,38 +2,17 @@ const fs = require('fs');
 const nativeCSS = require('native-css');
 const R = require('ramda');
 
-const tachyonsModules = require('tachyons-modules');
-const moduleWhitelist = require('./whitelist')
-
-/*
-const moduleBlacklist = [
-  'react-native-style-tachyons',
-  'tachyons-base',
-  'tachyons-build-css',
-  'tachyons-debug',
-  'tachyons-display-verbose',
-  'tachyons-verbose',
-  'tachyons-webpack',
-];
-*/
+const moduleWhitelist = require('./whitelist');
 
 // concatMediaQueries :: String -> { k: v } -> { k: v } -> *
 function concatMediaQueries (key, left, right) {
   return R.merge(left, right);
-}
+};
 
 // toJS :: CSS -> { k: v }
 const toJS = R.reduce((acc, [k, v]) => {
   return R.mergeWithKey(concatMediaQueries, acc, nativeCSS.convert(v));
-}, {})
-
-/*
-const queries = {
-  '@media (--breakpoint-not-small)': '@media screen and (min-width: 48em)',
-  '@media (--breakpoint-medium)': '@media screen and (min-width: 48em) and (max-width: 64em)',
-  '@media (--breakpoint-large)': '@media screen and (min-width: 64em)',
-}
-*/
+}, {});
 
 const queries = {
   '@media (--breakpoint-not-small)': '@media screen and (min-width: 30em)',
@@ -54,17 +33,17 @@ const mergeMediaQueries = styles => {
       const newBp = queries[key];
       return R.assocPath([selector, newBp], rules[selector], acc);
     }, {}, R.keys(rules));
-  }
+  };
 
   const flippedQueries = R.reduce((acc, key) => {
     return R.merge(acc, flipMediaQuery(key));
   }, {}, queryKeys);
 
   return R.merge(noQueries, flippedQueries);
-}
+};
 
 // addExports :: String -> String
-function addExports(json) { return `module.exports = ${json}` }
+function addExports(json) { return `module.exports = ${json}` };
 
 // toJSON :: { k: v } -> JSON
 const toJSON = R.compose(
@@ -80,7 +59,7 @@ function writeFile(file) {
       res(result);
     })
   })
-}
+};
 
 // constructFile :: { k: v } -> String -> { k: v }
 function constructFile (modules, module) {
@@ -88,17 +67,17 @@ function constructFile (modules, module) {
   var moduleName = getModuleKey(module)
   // const key = '_' + moduleName + '.css';
   return R.assoc(moduleName, moduleLocation, modules);
-}
+};
 
 // isTachyonsModule :: String -> Boolean
 function isTachyonsModule (module) {
   return module.indexOf('tachyons') !== -1
-}
+};
 
 // isNormalizeModule :: String -> Boolean
 function isNormalizeModule (module) {
   return module === 'normalize.css'
-}
+};
 
 // getModuleCssLocation :: String -> String
 function getModuleCssLocation (module) {
@@ -108,25 +87,25 @@ function getModuleCssLocation (module) {
     } else if (isNormalizeModule(module)) {
       return 'node_modules/' + module + '/' + module
     } else {
-      console.error('Unknown module: ' + module)
+      console.error('Unknown module: ' + module);
     }
   } catch (e) {
-    console.log(e)
+    console.log(e);
   }
-}
+};
 
 // getModuleKey :: String -> String
 function getModuleKey (module) {
-  return R.replace(/(tachyons-|\.css)/ig, '', module)
-}
+  return R.replace(/(tachyons-|\.css)/ig, '', module);
+};
 
 // hoverRegex :: RegExp
 const hoverRegex = /_hover$/
 
 // isHoverStyle :: String -> Boolean
-const isHoverStyle = R.test(hoverRegex)
+const isHoverStyle = R.test(hoverRegex);
 
-const stripHoverSuffix = R.replace(hoverRegex, '')
+const stripHoverSuffix = R.replace(hoverRegex, '');
 
 const extractHoverStyles = styles => {
   return R.reduce((acc, key) => {
@@ -138,20 +117,18 @@ const extractHoverStyles = styles => {
           R.dissoc(key),
           R.assoc(':hover', styles[key])
         )(acc);
-      }
+      };
 
       return R.compose(
         R.dissoc(key),
         R.assoc(rootKey, { ':hover': styles[key] })
       )(acc);
-    }
+    };
     return acc;
   }, styles, R.keys(styles));
-}
+};
 
-tachyonsModules()
-  .then(R.pluck('name'))
-  .then(R.filter(R.contains(R.__, moduleWhitelist)))
+Promise.all(moduleWhitelist.map(name => name))
   .then(R.reduce(constructFile, {}))
   .then(R.toPairs)
   .then(toJS)

--- a/index.js
+++ b/index.js
@@ -1,4 +1,120 @@
 module.exports = {
+  "html": {
+    "box-sizing": "border-box"
+  },
+  "body": {
+    "box-sizing": "border-box"
+  },
+  "div": {
+    "box-sizing": "border-box"
+  },
+  "article": {
+    "box-sizing": "border-box"
+  },
+  "section": {
+    "box-sizing": "border-box"
+  },
+  "main": {
+    "box-sizing": "border-box"
+  },
+  "footer": {
+    "box-sizing": "border-box"
+  },
+  "header": {
+    "box-sizing": "border-box"
+  },
+  "form": {
+    "box-sizing": "border-box"
+  },
+  "fieldset": {
+    "box-sizing": "border-box"
+  },
+  "legend": {
+    "box-sizing": "border-box"
+  },
+  "pre": {
+    "box-sizing": "border-box",
+    "overflow-x": "auto",
+    "overflow-y": "hidden",
+    "overflow": "scroll",
+    "white-space": "pre"
+  },
+  "code": {
+    "box-sizing": "border-box",
+    "font-family": "Consolas,\n               monaco,\n               monospace"
+  },
+  "p": {
+    "box-sizing": "border-box"
+  },
+  "a": {
+    "box-sizing": "border-box"
+  },
+  "h1": {
+    "box-sizing": "border-box",
+    "height": "1rem"
+  },
+  "h2": {
+    "box-sizing": "border-box",
+    "height": "2rem"
+  },
+  "h3": {
+    "box-sizing": "border-box",
+    "height": "4rem"
+  },
+  "h4": {
+    "box-sizing": "border-box",
+    "height": "8rem"
+  },
+  "h5": {
+    "box-sizing": "border-box",
+    "height": "16rem"
+  },
+  "h6": {
+    "box-sizing": "border-box"
+  },
+  "ul": {
+    "box-sizing": "border-box"
+  },
+  "ol": {
+    "box-sizing": "border-box"
+  },
+  "li": {
+    "box-sizing": "border-box"
+  },
+  "dl": {
+    "box-sizing": "border-box"
+  },
+  "dt": {
+    "box-sizing": "border-box",
+    "display": "table"
+  },
+  "dd": {
+    "box-sizing": "border-box"
+  },
+  "textarea": {
+    "box-sizing": "border-box"
+  },
+  "input_type__email": {
+    "box-sizing": "border-box"
+  },
+  "input_type__number": {
+    "box-sizing": "border-box"
+  },
+  "input_type__password": {
+    "box-sizing": "border-box"
+  },
+  "input_type__tel": {
+    "box-sizing": "border-box"
+  },
+  "input_type__text": {
+    "box-sizing": "border-box"
+  },
+  "input_type__url": {
+    "box-sizing": "border-box"
+  },
+  "border_box": {
+    "box-sizing": "border-box"
+  },
   "aspect_ratio": {
     "height": "0",
     "position": "relative"
@@ -46,6 +162,15 @@ module.exports = {
     "height": "100%",
     "z-index": "100"
   },
+  "img": {
+    "max-width": "100%"
+  },
+  "cover": {
+    "background-size": "cover"
+  },
+  "contain": {
+    "background-size": "contain"
+  },
   "bg_center": {
     "background-repeat": "no-repeat",
     "background-position": "center center"
@@ -66,11 +191,38 @@ module.exports = {
     "background-repeat": "no-repeat",
     "background-position": "center left"
   },
-  "cover": {
-    "background-size": "cover"
+  "outline": {
+    "outline": "1px solid"
   },
-  "contain": {
-    "background-size": "contain"
+  "outline_transparent": {
+    "outline": "1px solid transparent"
+  },
+  "outline_0": {
+    "outline": "0"
+  },
+  "ba": {
+    "border-style": "solid",
+    "border-width": "1px"
+  },
+  "bt": {
+    "border-top-style": "solid",
+    "border-top-width": "1px"
+  },
+  "br": {
+    "border-right-style": "solid",
+    "border-right-width": "1px"
+  },
+  "bb": {
+    "border-bottom-style": "solid",
+    "border-bottom-width": "1px"
+  },
+  "bl": {
+    "border-left-style": "solid",
+    "border-left-width": "1px"
+  },
+  "bn": {
+    "border-style": "none",
+    "border-width": "0"
   },
   "b__black": {
     "border-color": "var(--black)"
@@ -331,30 +483,6 @@ module.exports = {
   "bl_0": {
     "border-left-width": "0"
   },
-  "ba": {
-    "border-style": "solid",
-    "border-width": "1px"
-  },
-  "bt": {
-    "border-top-style": "solid",
-    "border-top-width": "1px"
-  },
-  "br": {
-    "border-right-style": "solid",
-    "border-right-width": "1px"
-  },
-  "bb": {
-    "border-bottom-style": "solid",
-    "border-bottom-width": "1px"
-  },
-  "bl": {
-    "border-left-style": "solid",
-    "border-left-width": "1px"
-  },
-  "bn": {
-    "border-style": "none",
-    "border-width": "0"
-  },
   "shadow_1": {
     "box-shadow": "0px 0px 4px 2px rgba( 0, 0, 0, 0.2 )"
   },
@@ -369,141 +497,6 @@ module.exports = {
   },
   "shadow_5": {
     "box-shadow": "4px 4px 8px 0px rgba( 0, 0, 0, 0.2 )"
-  },
-  "html": {
-    "box-sizing": "border-box"
-  },
-  "body": {
-    "box-sizing": "border-box"
-  },
-  "div": {
-    "box-sizing": "border-box"
-  },
-  "article": {
-    "box-sizing": "border-box"
-  },
-  "section": {
-    "box-sizing": "border-box"
-  },
-  "main": {
-    "box-sizing": "border-box"
-  },
-  "footer": {
-    "box-sizing": "border-box"
-  },
-  "header": {
-    "box-sizing": "border-box"
-  },
-  "form": {
-    "box-sizing": "border-box"
-  },
-  "fieldset": {
-    "box-sizing": "border-box"
-  },
-  "legend": {
-    "box-sizing": "border-box"
-  },
-  "pre": {
-    "box-sizing": "border-box",
-    "white-space": "pre"
-  },
-  "code": {
-    "box-sizing": "border-box",
-    "font-family": "Consolas,\n               monaco,\n               monospace"
-  },
-  "p": {
-    "box-sizing": "border-box"
-  },
-  "a": {
-    "box-sizing": "border-box"
-  },
-  "h1": {
-    "box-sizing": "border-box",
-    "height": "1rem"
-  },
-  "h2": {
-    "box-sizing": "border-box",
-    "height": "2rem"
-  },
-  "h3": {
-    "box-sizing": "border-box",
-    "height": "4rem"
-  },
-  "h4": {
-    "box-sizing": "border-box",
-    "height": "8rem"
-  },
-  "h5": {
-    "box-sizing": "border-box",
-    "height": "16rem"
-  },
-  "h6": {
-    "box-sizing": "border-box"
-  },
-  "ul": {
-    "box-sizing": "border-box"
-  },
-  "ol": {
-    "box-sizing": "border-box"
-  },
-  "li": {
-    "box-sizing": "border-box"
-  },
-  "dl": {
-    "box-sizing": "border-box"
-  },
-  "dt": {
-    "box-sizing": "border-box",
-    "display": "table"
-  },
-  "dd": {
-    "box-sizing": "border-box"
-  },
-  "textarea": {
-    "box-sizing": "border-box"
-  },
-  "input_type__email": {
-    "box-sizing": "border-box"
-  },
-  "input_type__number": {
-    "box-sizing": "border-box"
-  },
-  "input_type__password": {
-    "box-sizing": "border-box"
-  },
-  "input_type__tel": {
-    "box-sizing": "border-box"
-  },
-  "input_type__text": {
-    "box-sizing": "border-box"
-  },
-  "input_type__url": {
-    "box-sizing": "border-box"
-  },
-  "border_box": {
-    "box-sizing": "border-box"
-  },
-  "cf_before": {
-    "content": "\" \"",
-    "display": "table"
-  },
-  "cf_after": {
-    "clear": "both"
-  },
-  "cf": {
-    "*zoom": "1"
-  },
-  "cl": {
-    "clear": "left"
-  },
-  "cr": {
-    "clear": "right"
-  },
-  "cb": {
-    "clear": "both"
-  },
-  "cn": {
-    "clear": "none"
   },
   "top_0": {
     "top": "0"
@@ -570,6 +563,28 @@ module.exports = {
     "right": "0",
     "bottom": "0",
     "left": "0"
+  },
+  "cf_before": {
+    "content": "\" \"",
+    "display": "table"
+  },
+  "cf_after": {
+    "clear": "both"
+  },
+  "cf": {
+    "*zoom": "1"
+  },
+  "cl": {
+    "clear": "left"
+  },
+  "cr": {
+    "clear": "right"
+  },
+  "cb": {
+    "clear": "both"
+  },
+  "cn": {
+    "clear": "none"
   },
   "dn": {
     "display": "none"
@@ -861,81 +876,6 @@ module.exports = {
   "h_inherit": {
     "height": "inherit"
   },
-  "dim": {
-    "opacity": "1",
-    "transition": "opacity .15s ease-in"
-  },
-  "dim_focus": {
-    "opacity": ".5",
-    "transition": "opacity .15s ease-in"
-  },
-  "dim_active": {
-    "opacity": ".8",
-    "transition": "opacity .15s ease-out"
-  },
-  "hide_child__child": {
-    "opacity": "0",
-    "transition": "opacity .15s ease-in"
-  },
-  "hide_child_hover__child": {
-    "opacity": "1",
-    "transition": "opacity .15s ease-in"
-  },
-  "hide_child_focus__child": {
-    "opacity": "1",
-    "transition": "opacity .15s ease-in"
-  },
-  "hide_child_active__child": {
-    "opacity": "1",
-    "transition": "opacity .15s ease-in"
-  },
-  "underline_hover_focus": {
-    "text-decoration": "underline"
-  },
-  "grow": {
-    "-moz-osx-font-smoothing": "grayscale",
-    "backface-visibility": "hidden",
-    "transform": "translateZ(0)",
-    "transition": "transform 0.25s ease-out"
-  },
-  "grow_focus": {
-    "transform": "scale(1.05)"
-  },
-  "grow_active": {
-    "transform": "scale(.90)"
-  },
-  "grow_large": {
-    "-moz-osx-font-smoothing": "grayscale",
-    "backface-visibility": "hidden",
-    "transform": "translateZ(0)",
-    "transition": "transform .25s ease-in-out"
-  },
-  "grow_large_focus": {
-    "transform": "scale(1.2)"
-  },
-  "grow_large_active": {
-    "transform": "scale(.95)"
-  },
-  "shadow_hover__after": {
-    "box-shadow": "0px 0px 8px 2px rgba( 0, 0, 0, .2 )",
-    "opacity": "0",
-    "transition": "opacity .25s ease-in-out"
-  },
-  "shadow_hover_hover__after": {
-    "opacity": "1"
-  },
-  "shadow_hover_focus__after": {
-    "opacity": "1"
-  },
-  "bg_animate": {
-    "transition": "background-color .15s ease-in-out"
-  },
-  "bg_animate_focus": {
-    "transition": "background-color .15s ease-in-out"
-  },
-  "img": {
-    "max-width": "100%"
-  },
   "tracked": {
     "letter-spacing": ".1em"
   },
@@ -1006,53 +946,71 @@ module.exports = {
   "mw_none": {
     "max-width": "none"
   },
-  "o_100": {
-    "opacity": "1"
+  "w1": {
+    "width": "1rem"
   },
-  "o_90": {
-    "opacity": ".9"
+  "w2": {
+    "width": "2rem"
   },
-  "o_80": {
-    "opacity": ".8"
+  "w3": {
+    "width": "4rem"
   },
-  "o_70": {
-    "opacity": ".7"
+  "w4": {
+    "width": "8rem"
   },
-  "o_60": {
-    "opacity": ".6"
+  "w5": {
+    "width": "16rem"
   },
-  "o_50": {
-    "opacity": ".5"
+  "w_10": {
+    "width": "10%"
   },
-  "o_40": {
-    "opacity": ".4"
+  "w_20": {
+    "width": "20%"
   },
-  "o_30": {
-    "opacity": ".3"
+  "w_25": {
+    "width": "25%"
   },
-  "o_20": {
-    "opacity": ".2"
+  "w_30": {
+    "width": "30%"
   },
-  "o_10": {
-    "opacity": ".1"
+  "w_33": {
+    "width": "33%"
   },
-  "o_05": {
-    "opacity": ".05"
+  "w_34": {
+    "width": "34%"
   },
-  "o_025": {
-    "opacity": ".025"
+  "w_40": {
+    "width": "40%"
   },
-  "o_0": {
-    "opacity": "0"
+  "w_50": {
+    "width": "50%"
   },
-  "outline": {
-    "outline": "1px solid"
+  "w_60": {
+    "width": "60%"
   },
-  "outline_transparent": {
-    "outline": "1px solid transparent"
+  "w_70": {
+    "width": "70%"
   },
-  "outline_0": {
-    "outline": "0"
+  "w_75": {
+    "width": "75%"
+  },
+  "w_80": {
+    "width": "80%"
+  },
+  "w_90": {
+    "width": "90%"
+  },
+  "w_100": {
+    "width": "100%"
+  },
+  "w_third": {
+    "width": "calc(100% / 3)"
+  },
+  "w_two_thirds": {
+    "width": "calc(100% / 1.5)"
+  },
+  "w_auto": {
+    "width": "auto"
   },
   "overflow_visible": {
     "overflow": "visible"
@@ -1101,6 +1059,45 @@ module.exports = {
   },
   "fixed": {
     "position": "fixed"
+  },
+  "o_100": {
+    "opacity": "1"
+  },
+  "o_90": {
+    "opacity": ".9"
+  },
+  "o_80": {
+    "opacity": ".8"
+  },
+  "o_70": {
+    "opacity": ".7"
+  },
+  "o_60": {
+    "opacity": ".6"
+  },
+  "o_50": {
+    "opacity": ".5"
+  },
+  "o_40": {
+    "opacity": ".4"
+  },
+  "o_30": {
+    "opacity": ".3"
+  },
+  "o_20": {
+    "opacity": ".2"
+  },
+  "o_10": {
+    "opacity": ".1"
+  },
+  "o_05": {
+    "opacity": ".05"
+  },
+  "o_025": {
+    "opacity": ".025"
+  },
+  "o_0": {
+    "opacity": "0"
   },
   "rotate_45": {
     "transform": "rotate(45deg)"
@@ -2053,15 +2050,6 @@ module.exports = {
   "striped__near_white_nth_child_odd": {
     "background-color": "var(--near-white)"
   },
-  "tl": {
-    "text-align": "left"
-  },
-  "tr": {
-    "text-align": "right"
-  },
-  "tc": {
-    "text-align": "center"
-  },
   "strike": {
     "text-decoration": "line-through"
   },
@@ -2070,6 +2058,15 @@ module.exports = {
   },
   "no_underline": {
     "text-decoration": "none"
+  },
+  "tl": {
+    "text-align": "left"
+  },
+  "tr": {
+    "text-align": "right"
+  },
+  "tc": {
+    "text-align": "center"
   },
   "ttc": {
     "text-transform": "capitalize"
@@ -2142,6 +2139,17 @@ module.exports = {
     "margin-right": "auto",
     "margin-left": "auto"
   },
+  "clip": {
+    "position": "fixed !important",
+    "_position": "absolute !important",
+    "clip": "rect(1px, 1px, 1px, 1px)"
+  },
+  "ws_normal": {
+    "white-space": "normal"
+  },
+  "nowrap": {
+    "white-space": "nowrap"
+  },
   "v_base": {
     "vertical-align": "baseline"
   },
@@ -2154,82 +2162,77 @@ module.exports = {
   "v_btm": {
     "vertical-align": "bottom"
   },
-  "clip": {
-    "position": "fixed !important",
-    "_position": "absolute !important",
-    "clip": "rect(1px, 1px, 1px, 1px)"
+  "dim": {
+    "opacity": "1",
+    "transition": "opacity .15s ease-in"
   },
-  "ws_normal": {
-    "white-space": "normal"
+  "dim_focus": {
+    "opacity": ".5",
+    "transition": "opacity .15s ease-in"
   },
-  "nowrap": {
-    "white-space": "nowrap"
+  "dim_active": {
+    "opacity": ".8",
+    "transition": "opacity .15s ease-out"
   },
-  "w1": {
-    "width": "1rem"
+  "hide_child__child": {
+    "opacity": "0",
+    "transition": "opacity .15s ease-in"
   },
-  "w2": {
-    "width": "2rem"
+  "hide_child_hover__child": {
+    "opacity": "1",
+    "transition": "opacity .15s ease-in"
   },
-  "w3": {
-    "width": "4rem"
+  "hide_child_focus__child": {
+    "opacity": "1",
+    "transition": "opacity .15s ease-in"
   },
-  "w4": {
-    "width": "8rem"
+  "hide_child_active__child": {
+    "opacity": "1",
+    "transition": "opacity .15s ease-in"
   },
-  "w5": {
-    "width": "16rem"
+  "underline_hover_focus": {
+    "text-decoration": "underline"
   },
-  "w_10": {
-    "width": "10%"
+  "grow": {
+    "-moz-osx-font-smoothing": "grayscale",
+    "backface-visibility": "hidden",
+    "transform": "translateZ(0)",
+    "transition": "transform 0.25s ease-out"
   },
-  "w_20": {
-    "width": "20%"
+  "grow_focus": {
+    "transform": "scale(1.05)"
   },
-  "w_25": {
-    "width": "25%"
+  "grow_active": {
+    "transform": "scale(.90)"
   },
-  "w_30": {
-    "width": "30%"
+  "grow_large": {
+    "-moz-osx-font-smoothing": "grayscale",
+    "backface-visibility": "hidden",
+    "transform": "translateZ(0)",
+    "transition": "transform .25s ease-in-out"
   },
-  "w_33": {
-    "width": "33%"
+  "grow_large_focus": {
+    "transform": "scale(1.2)"
   },
-  "w_34": {
-    "width": "34%"
+  "grow_large_active": {
+    "transform": "scale(.95)"
   },
-  "w_40": {
-    "width": "40%"
+  "shadow_hover__after": {
+    "box-shadow": "0px 0px 8px 2px rgba( 0, 0, 0, .2 )",
+    "opacity": "0",
+    "transition": "opacity .25s ease-in-out"
   },
-  "w_50": {
-    "width": "50%"
+  "shadow_hover_hover__after": {
+    "opacity": "1"
   },
-  "w_60": {
-    "width": "60%"
+  "shadow_hover_focus__after": {
+    "opacity": "1"
   },
-  "w_70": {
-    "width": "70%"
+  "bg_animate": {
+    "transition": "background-color .15s ease-in-out"
   },
-  "w_75": {
-    "width": "75%"
-  },
-  "w_80": {
-    "width": "80%"
-  },
-  "w_90": {
-    "width": "90%"
-  },
-  "w_100": {
-    "width": "100%"
-  },
-  "w_third": {
-    "width": "calc(100% / 3)"
-  },
-  "w_two_thirds": {
-    "width": "calc(100% / 1.5)"
-  },
-  "w_auto": {
-    "width": "auto"
+  "bg_animate_focus": {
+    "transition": "background-color .15s ease-in-out"
   },
   "z_0": {
     "z-index": "0"
@@ -2343,6 +2346,16 @@ module.exports = {
       "z-index": "100"
     }
   },
+  "cover_ns": {
+    "@media screen and (min-width: 30em)": {
+      "background-size": "cover"
+    }
+  },
+  "contain_ns": {
+    "@media screen and (min-width: 30em)": {
+      "background-size": "contain"
+    }
+  },
   "bg_center_ns": {
     "@media screen and (min-width: 30em)": {
       "background-repeat": "no-repeat",
@@ -2373,14 +2386,55 @@ module.exports = {
       "background-position": "center left"
     }
   },
-  "cover_ns": {
+  "outline_ns": {
     "@media screen and (min-width: 30em)": {
-      "background-size": "cover"
+      "outline": "1px solid"
     }
   },
-  "contain_ns": {
+  "outline_transparent_ns": {
     "@media screen and (min-width: 30em)": {
-      "background-size": "contain"
+      "outline": "1px solid transparent"
+    }
+  },
+  "outline_0_ns": {
+    "@media screen and (min-width: 30em)": {
+      "outline": "0"
+    }
+  },
+  "ba_ns": {
+    "@media screen and (min-width: 30em)": {
+      "border-style": "solid",
+      "border-width": "1px"
+    }
+  },
+  "bt_ns": {
+    "@media screen and (min-width: 30em)": {
+      "border-top-style": "solid",
+      "border-top-width": "1px"
+    }
+  },
+  "br_ns": {
+    "@media screen and (min-width: 30em)": {
+      "border-right-style": "solid",
+      "border-right-width": "1px"
+    }
+  },
+  "bb_ns": {
+    "@media screen and (min-width: 30em)": {
+      "border-bottom-style": "solid",
+      "border-bottom-width": "1px"
+    }
+  },
+  "bl_ns": {
+    "@media screen and (min-width: 30em)": {
+      "border-left-style": "solid",
+      "border-left-width": "1px"
+    }
+  },
+  "bn_ns": {
+    "@media screen and (min-width: 30em)": {
+      "border-style": "none",
+      "border-width": "0"
     }
   },
   "br0_ns": {
@@ -2512,42 +2566,6 @@ module.exports = {
       "border-left-width": "0"
     }
   },
-  "ba_ns": {
-    "@media screen and (min-width: 30em)": {
-      "border-style": "solid",
-      "border-width": "1px"
-    }
-  },
-  "bt_ns": {
-    "@media screen and (min-width: 30em)": {
-      "border-top-style": "solid",
-      "border-top-width": "1px"
-    }
-  },
-  "br_ns": {
-    "@media screen and (min-width: 30em)": {
-      "border-right-style": "solid",
-      "border-right-width": "1px"
-    }
-  },
-  "bb_ns": {
-    "@media screen and (min-width: 30em)": {
-      "border-bottom-style": "solid",
-      "border-bottom-width": "1px"
-    }
-  },
-  "bl_ns": {
-    "@media screen and (min-width: 30em)": {
-      "border-left-style": "solid",
-      "border-left-width": "1px"
-    }
-  },
-  "bn_ns": {
-    "@media screen and (min-width: 30em)": {
-      "border-style": "none",
-      "border-width": "0"
-    }
-  },
   "shadow_1_ns": {
     "@media screen and (min-width: 30em)": {
       "box-shadow": "0px 0px 4px 2px rgba( 0, 0, 0, 0.2 )"
@@ -2571,26 +2589,6 @@ module.exports = {
   "shadow_5_ns": {
     "@media screen and (min-width: 30em)": {
       "box-shadow": "4px 4px 8px 0px rgba( 0, 0, 0, 0.2 )"
-    }
-  },
-  "cl_ns": {
-    "@media screen and (min-width: 30em)": {
-      "clear": "left"
-    }
-  },
-  "cr_ns": {
-    "@media screen and (min-width: 30em)": {
-      "clear": "right"
-    }
-  },
-  "cb_ns": {
-    "@media screen and (min-width: 30em)": {
-      "clear": "both"
-    }
-  },
-  "cn_ns": {
-    "@media screen and (min-width: 30em)": {
-      "clear": "none"
     }
   },
   "top_0_ns": {
@@ -2699,6 +2697,26 @@ module.exports = {
       "right": "0",
       "bottom": "0",
       "left": "0"
+    }
+  },
+  "cl_ns": {
+    "@media screen and (min-width: 30em)": {
+      "clear": "left"
+    }
+  },
+  "cr_ns": {
+    "@media screen and (min-width: 30em)": {
+      "clear": "right"
+    }
+  },
+  "cb_ns": {
+    "@media screen and (min-width: 30em)": {
+      "clear": "both"
+    }
+  },
+  "cn_ns": {
+    "@media screen and (min-width: 30em)": {
+      "clear": "none"
     }
   },
   "dn_ns": {
@@ -3206,19 +3224,114 @@ module.exports = {
       "max-width": "none"
     }
   },
-  "outline_ns": {
+  "w1_ns": {
     "@media screen and (min-width: 30em)": {
-      "outline": "1px solid"
+      "width": "1rem"
     }
   },
-  "outline_transparent_ns": {
+  "w2_ns": {
     "@media screen and (min-width: 30em)": {
-      "outline": "1px solid transparent"
+      "width": "2rem"
     }
   },
-  "outline_0_ns": {
+  "w3_ns": {
     "@media screen and (min-width: 30em)": {
-      "outline": "0"
+      "width": "4rem"
+    }
+  },
+  "w4_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "8rem"
+    }
+  },
+  "w5_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "16rem"
+    }
+  },
+  "w_10_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "10%"
+    }
+  },
+  "w_20_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "20%"
+    }
+  },
+  "w_25_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "25%"
+    }
+  },
+  "w_30_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "30%"
+    }
+  },
+  "w_33_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "33%"
+    }
+  },
+  "w_34_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "34%"
+    }
+  },
+  "w_40_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "40%"
+    }
+  },
+  "w_50_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "50%"
+    }
+  },
+  "w_60_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "60%"
+    }
+  },
+  "w_70_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "70%"
+    }
+  },
+  "w_75_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "75%"
+    }
+  },
+  "w_80_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "80%"
+    }
+  },
+  "w_90_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "90%"
+    }
+  },
+  "w_100_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "100%"
+    }
+  },
+  "w_third_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "calc(100% / 3)"
+    }
+  },
+  "w_two_thirds_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "calc(100% / 1.5)"
+    }
+  },
+  "w_auto_ns": {
+    "@media screen and (min-width: 30em)": {
+      "width": "auto"
     }
   },
   "overflow_visible_ns": {
@@ -3928,21 +4041,6 @@ module.exports = {
       "margin-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
-  "tl_ns": {
-    "@media screen and (min-width: 30em)": {
-      "text-align": "left"
-    }
-  },
-  "tr_ns": {
-    "@media screen and (min-width: 30em)": {
-      "text-align": "right"
-    }
-  },
-  "tc_ns": {
-    "@media screen and (min-width: 30em)": {
-      "text-align": "center"
-    }
-  },
   "strike_ns": {
     "@media screen and (min-width: 30em)": {
       "text-decoration": "line-through"
@@ -3956,6 +4054,21 @@ module.exports = {
   "no_underline_ns": {
     "@media screen and (min-width: 30em)": {
       "text-decoration": "none"
+    }
+  },
+  "tl_ns": {
+    "@media screen and (min-width: 30em)": {
+      "text-align": "left"
+    }
+  },
+  "tr_ns": {
+    "@media screen and (min-width: 30em)": {
+      "text-align": "right"
+    }
+  },
+  "tc_ns": {
+    "@media screen and (min-width: 30em)": {
+      "text-align": "center"
     }
   },
   "ttc_ns": {
@@ -4062,26 +4175,6 @@ module.exports = {
       "text-overflow": "ellipsis"
     }
   },
-  "v_base_ns": {
-    "@media screen and (min-width: 30em)": {
-      "vertical-align": "baseline"
-    }
-  },
-  "v_mid_ns": {
-    "@media screen and (min-width: 30em)": {
-      "vertical-align": "middle"
-    }
-  },
-  "v_top_ns": {
-    "@media screen and (min-width: 30em)": {
-      "vertical-align": "top"
-    }
-  },
-  "v_btm_ns": {
-    "@media screen and (min-width: 30em)": {
-      "vertical-align": "bottom"
-    }
-  },
   "clip_ns": {
     "@media screen and (min-width: 30em)": {
       "position": "fixed !important",
@@ -4104,114 +4197,24 @@ module.exports = {
       "white-space": "pre"
     }
   },
-  "w1_ns": {
+  "v_base_ns": {
     "@media screen and (min-width: 30em)": {
-      "width": "1rem"
+      "vertical-align": "baseline"
     }
   },
-  "w2_ns": {
+  "v_mid_ns": {
     "@media screen and (min-width: 30em)": {
-      "width": "2rem"
+      "vertical-align": "middle"
     }
   },
-  "w3_ns": {
+  "v_top_ns": {
     "@media screen and (min-width: 30em)": {
-      "width": "4rem"
+      "vertical-align": "top"
     }
   },
-  "w4_ns": {
+  "v_btm_ns": {
     "@media screen and (min-width: 30em)": {
-      "width": "8rem"
-    }
-  },
-  "w5_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "16rem"
-    }
-  },
-  "w_10_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "10%"
-    }
-  },
-  "w_20_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "20%"
-    }
-  },
-  "w_25_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "25%"
-    }
-  },
-  "w_30_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "30%"
-    }
-  },
-  "w_33_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "33%"
-    }
-  },
-  "w_34_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "34%"
-    }
-  },
-  "w_40_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "40%"
-    }
-  },
-  "w_50_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "50%"
-    }
-  },
-  "w_60_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "60%"
-    }
-  },
-  "w_70_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "70%"
-    }
-  },
-  "w_75_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "75%"
-    }
-  },
-  "w_80_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "80%"
-    }
-  },
-  "w_90_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "90%"
-    }
-  },
-  "w_100_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "100%"
-    }
-  },
-  "w_third_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "calc(100% / 3)"
-    }
-  },
-  "w_two_thirds_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "calc(100% / 1.5)"
-    }
-  },
-  "w_auto_ns": {
-    "@media screen and (min-width: 30em)": {
-      "width": "auto"
+      "vertical-align": "bottom"
     }
   },
   "aspect_ratio_m": {
@@ -4287,6 +4290,16 @@ module.exports = {
       "z-index": "100"
     }
   },
+  "cover_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "background-size": "cover"
+    }
+  },
+  "contain_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "background-size": "contain"
+    }
+  },
   "bg_center_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "background-repeat": "no-repeat",
@@ -4317,14 +4330,70 @@ module.exports = {
       "background-position": "center left"
     }
   },
-  "cover_m": {
+  "outline_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "background-size": "cover"
+      "outline": "1px solid"
     }
   },
-  "contain_m": {
+  "outline_transparent_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "background-size": "contain"
+      "outline": "1px solid transparent"
+    }
+  },
+  "outline_0_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "outline": "0"
+    }
+  },
+  "outline_l": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "outline": "1px solid"
+    }
+  },
+  "outline_transparent_l": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "outline": "1px solid transparent"
+    }
+  },
+  "outline_0_l": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "outline": "0"
+    }
+  },
+  "ba_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "border-style": "solid",
+      "border-width": "1px"
+    }
+  },
+  "bt_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "border-top-style": "solid",
+      "border-top-width": "1px"
+    }
+  },
+  "br_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "border-right-style": "solid",
+      "border-right-width": "1px"
+    }
+  },
+  "bb_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "border-bottom-style": "solid",
+      "border-bottom-width": "1px"
+    }
+  },
+  "bl_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "border-left-style": "solid",
+      "border-left-width": "1px"
+    }
+  },
+  "bn_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "border-style": "none",
+      "border-width": "0"
     }
   },
   "br0_m": {
@@ -4456,42 +4525,6 @@ module.exports = {
       "border-left-width": "0"
     }
   },
-  "ba_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "border-style": "solid",
-      "border-width": "1px"
-    }
-  },
-  "bt_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "border-top-style": "solid",
-      "border-top-width": "1px"
-    }
-  },
-  "br_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "border-right-style": "solid",
-      "border-right-width": "1px"
-    }
-  },
-  "bb_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "border-bottom-style": "solid",
-      "border-bottom-width": "1px"
-    }
-  },
-  "bl_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "border-left-style": "solid",
-      "border-left-width": "1px"
-    }
-  },
-  "bn_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "border-style": "none",
-      "border-width": "0"
-    }
-  },
   "shadow_1_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "box-shadow": "0px 0px 4px 2px rgba( 0, 0, 0, 0.2 )"
@@ -4515,26 +4548,6 @@ module.exports = {
   "shadow_5_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "box-shadow": "4px 4px 8px 0px rgba( 0, 0, 0, 0.2 )"
-    }
-  },
-  "cl_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "clear": "left"
-    }
-  },
-  "cr_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "clear": "right"
-    }
-  },
-  "cb_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "clear": "both"
-    }
-  },
-  "cn_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "clear": "none"
     }
   },
   "top_0_m": {
@@ -4643,6 +4656,26 @@ module.exports = {
       "right": "0",
       "bottom": "0",
       "left": "0"
+    }
+  },
+  "cl_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "clear": "left"
+    }
+  },
+  "cr_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "clear": "right"
+    }
+  },
+  "cb_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "clear": "both"
+    }
+  },
+  "cn_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "clear": "none"
     }
   },
   "dn_m": {
@@ -5145,34 +5178,114 @@ module.exports = {
       "max-width": "none"
     }
   },
-  "outline_m": {
+  "w1_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "outline": "1px solid"
+      "width": "1rem"
     }
   },
-  "outline_transparent_m": {
+  "w2_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "outline": "1px solid transparent"
+      "width": "2rem"
     }
   },
-  "outline_0_m": {
+  "w3_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "outline": "0"
+      "width": "4rem"
     }
   },
-  "outline_l": {
+  "w4_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "outline": "1px solid"
+      "width": "8rem"
     }
   },
-  "outline_transparent_l": {
+  "w5_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "outline": "1px solid transparent"
+      "width": "16rem"
     }
   },
-  "outline_0_l": {
+  "w_10_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "outline": "0"
+      "width": "10%"
+    }
+  },
+  "w_20_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "20%"
+    }
+  },
+  "w_25_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "25%"
+    }
+  },
+  "w_30_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "30%"
+    }
+  },
+  "w_33_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "33%"
+    }
+  },
+  "w_34_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "34%"
+    }
+  },
+  "w_40_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "40%"
+    }
+  },
+  "w_50_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "50%"
+    }
+  },
+  "w_60_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "60%"
+    }
+  },
+  "w_70_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "70%"
+    }
+  },
+  "w_75_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "75%"
+    }
+  },
+  "w_80_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "80%"
+    }
+  },
+  "w_90_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "90%"
+    }
+  },
+  "w_100_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "100%"
+    }
+  },
+  "w_third_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "calc(100% / 3)"
+    }
+  },
+  "w_two_thirds_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "calc(100% / 1.5)"
+    }
+  },
+  "w_auto_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "width": "auto"
     }
   },
   "overflow_visible_m": {
@@ -5882,21 +5995,6 @@ module.exports = {
       "margin-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
-  "tl_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "text-align": "left"
-    }
-  },
-  "tr_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "text-align": "right"
-    }
-  },
-  "tc_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "text-align": "center"
-    }
-  },
   "strike_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "text-decoration": "line-through"
@@ -5910,6 +6008,21 @@ module.exports = {
   "no_underline_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "text-decoration": "none"
+    }
+  },
+  "tl_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "text-align": "left"
+    }
+  },
+  "tr_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "text-align": "right"
+    }
+  },
+  "tc_m": {
+    "@media screen and (min-width: 30em) and (max-width: 60em)": {
+      "text-align": "center"
     }
   },
   "ttc_m": {
@@ -6016,26 +6129,6 @@ module.exports = {
       "text-overflow": "ellipsis"
     }
   },
-  "v_base_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "vertical-align": "baseline"
-    }
-  },
-  "v_mid_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "vertical-align": "middle"
-    }
-  },
-  "v_top_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "vertical-align": "top"
-    }
-  },
-  "v_btm_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "vertical-align": "bottom"
-    }
-  },
   "clip_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
       "position": "fixed !important",
@@ -6058,114 +6151,24 @@ module.exports = {
       "white-space": "pre"
     }
   },
-  "w1_m": {
+  "v_base_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "1rem"
+      "vertical-align": "baseline"
     }
   },
-  "w2_m": {
+  "v_mid_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "2rem"
+      "vertical-align": "middle"
     }
   },
-  "w3_m": {
+  "v_top_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "4rem"
+      "vertical-align": "top"
     }
   },
-  "w4_m": {
+  "v_btm_m": {
     "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "8rem"
-    }
-  },
-  "w5_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "16rem"
-    }
-  },
-  "w_10_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "10%"
-    }
-  },
-  "w_20_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "20%"
-    }
-  },
-  "w_25_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "25%"
-    }
-  },
-  "w_30_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "30%"
-    }
-  },
-  "w_33_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "33%"
-    }
-  },
-  "w_34_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "34%"
-    }
-  },
-  "w_40_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "40%"
-    }
-  },
-  "w_50_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "50%"
-    }
-  },
-  "w_60_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "60%"
-    }
-  },
-  "w_70_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "70%"
-    }
-  },
-  "w_75_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "75%"
-    }
-  },
-  "w_80_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "80%"
-    }
-  },
-  "w_90_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "90%"
-    }
-  },
-  "w_100_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "100%"
-    }
-  },
-  "w_third_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "calc(100% / 3)"
-    }
-  },
-  "w_two_thirds_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "calc(100% / 1.5)"
-    }
-  },
-  "w_auto_m": {
-    "@media screen and (min-width: 30em) and (max-width: 60em)": {
-      "width": "auto"
+      "vertical-align": "bottom"
     }
   },
   "aspect_ratio_l": {
@@ -6241,6 +6244,16 @@ module.exports = {
       "z-index": "100"
     }
   },
+  "cover_l": {
+    "@media screen and (min-width: 60em)": {
+      "background-size": "cover"
+    }
+  },
+  "contain_l": {
+    "@media screen and (min-width: 60em)": {
+      "background-size": "contain"
+    }
+  },
   "bg_center_l": {
     "@media screen and (min-width: 60em)": {
       "background-repeat": "no-repeat",
@@ -6271,14 +6284,40 @@ module.exports = {
       "background-position": "center left"
     }
   },
-  "cover_l": {
+  "ba_l": {
     "@media screen and (min-width: 60em)": {
-      "background-size": "cover"
+      "border-style": "solid",
+      "border-width": "1px"
     }
   },
-  "contain_l": {
+  "bt_l": {
     "@media screen and (min-width: 60em)": {
-      "background-size": "contain"
+      "border-top-style": "solid",
+      "border-top-width": "1px"
+    }
+  },
+  "br_l": {
+    "@media screen and (min-width: 60em)": {
+      "border-right-style": "solid",
+      "border-right-width": "1px"
+    }
+  },
+  "bb_l": {
+    "@media screen and (min-width: 60em)": {
+      "border-bottom-style": "solid",
+      "border-bottom-width": "1px"
+    }
+  },
+  "bl_l": {
+    "@media screen and (min-width: 60em)": {
+      "border-left-style": "solid",
+      "border-left-width": "1px"
+    }
+  },
+  "bn_l": {
+    "@media screen and (min-width: 60em)": {
+      "border-style": "none",
+      "border-width": "0"
     }
   },
   "br0_l": {
@@ -6410,42 +6449,6 @@ module.exports = {
       "border-left-width": "0"
     }
   },
-  "ba_l": {
-    "@media screen and (min-width: 60em)": {
-      "border-style": "solid",
-      "border-width": "1px"
-    }
-  },
-  "bt_l": {
-    "@media screen and (min-width: 60em)": {
-      "border-top-style": "solid",
-      "border-top-width": "1px"
-    }
-  },
-  "br_l": {
-    "@media screen and (min-width: 60em)": {
-      "border-right-style": "solid",
-      "border-right-width": "1px"
-    }
-  },
-  "bb_l": {
-    "@media screen and (min-width: 60em)": {
-      "border-bottom-style": "solid",
-      "border-bottom-width": "1px"
-    }
-  },
-  "bl_l": {
-    "@media screen and (min-width: 60em)": {
-      "border-left-style": "solid",
-      "border-left-width": "1px"
-    }
-  },
-  "bn_l": {
-    "@media screen and (min-width: 60em)": {
-      "border-style": "none",
-      "border-width": "0"
-    }
-  },
   "shadow_1_l": {
     "@media screen and (min-width: 60em)": {
       "box-shadow": "0px 0px 4px 2px rgba( 0, 0, 0, 0.2 )"
@@ -6469,26 +6472,6 @@ module.exports = {
   "shadow_5_l": {
     "@media screen and (min-width: 60em)": {
       "box-shadow": "4px 4px 8px 0px rgba( 0, 0, 0, 0.2 )"
-    }
-  },
-  "cl_l": {
-    "@media screen and (min-width: 60em)": {
-      "clear": "left"
-    }
-  },
-  "cr_l": {
-    "@media screen and (min-width: 60em)": {
-      "clear": "right"
-    }
-  },
-  "cb_l": {
-    "@media screen and (min-width: 60em)": {
-      "clear": "both"
-    }
-  },
-  "cn_l": {
-    "@media screen and (min-width: 60em)": {
-      "clear": "none"
     }
   },
   "top_0_l": {
@@ -6597,6 +6580,26 @@ module.exports = {
       "right": "0",
       "bottom": "0",
       "left": "0"
+    }
+  },
+  "cl_l": {
+    "@media screen and (min-width: 60em)": {
+      "clear": "left"
+    }
+  },
+  "cr_l": {
+    "@media screen and (min-width: 60em)": {
+      "clear": "right"
+    }
+  },
+  "cb_l": {
+    "@media screen and (min-width: 60em)": {
+      "clear": "both"
+    }
+  },
+  "cn_l": {
+    "@media screen and (min-width: 60em)": {
+      "clear": "none"
     }
   },
   "dn_l": {
@@ -7097,6 +7100,116 @@ module.exports = {
   "mw_none_l": {
     "@media screen and (min-width: 60em)": {
       "max-width": "none"
+    }
+  },
+  "w1_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "1rem"
+    }
+  },
+  "w2_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "2rem"
+    }
+  },
+  "w3_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "4rem"
+    }
+  },
+  "w4_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "8rem"
+    }
+  },
+  "w5_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "16rem"
+    }
+  },
+  "w_10_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "10%"
+    }
+  },
+  "w_20_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "20%"
+    }
+  },
+  "w_25_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "25%"
+    }
+  },
+  "w_30_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "30%"
+    }
+  },
+  "w_33_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "33%"
+    }
+  },
+  "w_34_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "34%"
+    }
+  },
+  "w_40_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "40%"
+    }
+  },
+  "w_50_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "50%"
+    }
+  },
+  "w_60_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "60%"
+    }
+  },
+  "w_70_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "70%"
+    }
+  },
+  "w_75_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "75%"
+    }
+  },
+  "w_80_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "80%"
+    }
+  },
+  "w_90_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "90%"
+    }
+  },
+  "w_100_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "100%"
+    }
+  },
+  "w_third_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "calc(100% / 3)"
+    }
+  },
+  "w_two_thirds_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "calc(100% / 1.5)"
+    }
+  },
+  "w_auto_l": {
+    "@media screen and (min-width: 60em)": {
+      "width": "auto"
     }
   },
   "overflow_visible_l": {
@@ -7806,21 +7919,6 @@ module.exports = {
       "margin-right": "var(--spacing-extra-extra-extra-large)"
     }
   },
-  "tl_l": {
-    "@media screen and (min-width: 60em)": {
-      "text-align": "left"
-    }
-  },
-  "tr_l": {
-    "@media screen and (min-width: 60em)": {
-      "text-align": "right"
-    }
-  },
-  "tc_l": {
-    "@media screen and (min-width: 60em)": {
-      "text-align": "center"
-    }
-  },
   "strike_l": {
     "@media screen and (min-width: 60em)": {
       "text-decoration": "line-through"
@@ -7834,6 +7932,21 @@ module.exports = {
   "no_underline_l": {
     "@media screen and (min-width: 60em)": {
       "text-decoration": "none"
+    }
+  },
+  "tl_l": {
+    "@media screen and (min-width: 60em)": {
+      "text-align": "left"
+    }
+  },
+  "tr_l": {
+    "@media screen and (min-width: 60em)": {
+      "text-align": "right"
+    }
+  },
+  "tc_l": {
+    "@media screen and (min-width: 60em)": {
+      "text-align": "center"
     }
   },
   "ttc_l": {
@@ -7940,26 +8053,6 @@ module.exports = {
       "text-overflow": "ellipsis"
     }
   },
-  "v_base_l": {
-    "@media screen and (min-width: 60em)": {
-      "vertical-align": "baseline"
-    }
-  },
-  "v_mid_l": {
-    "@media screen and (min-width: 60em)": {
-      "vertical-align": "middle"
-    }
-  },
-  "v_top_l": {
-    "@media screen and (min-width: 60em)": {
-      "vertical-align": "top"
-    }
-  },
-  "v_btm_l": {
-    "@media screen and (min-width: 60em)": {
-      "vertical-align": "bottom"
-    }
-  },
   "clip_l": {
     "@media screen and (min-width: 60em)": {
       "position": "fixed !important",
@@ -7982,128 +8075,28 @@ module.exports = {
       "white-space": "pre"
     }
   },
-  "w1_l": {
+  "v_base_l": {
     "@media screen and (min-width: 60em)": {
-      "width": "1rem"
+      "vertical-align": "baseline"
     }
   },
-  "w2_l": {
+  "v_mid_l": {
     "@media screen and (min-width: 60em)": {
-      "width": "2rem"
+      "vertical-align": "middle"
     }
   },
-  "w3_l": {
+  "v_top_l": {
     "@media screen and (min-width: 60em)": {
-      "width": "4rem"
+      "vertical-align": "top"
     }
   },
-  "w4_l": {
+  "v_btm_l": {
     "@media screen and (min-width: 60em)": {
-      "width": "8rem"
-    }
-  },
-  "w5_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "16rem"
-    }
-  },
-  "w_10_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "10%"
-    }
-  },
-  "w_20_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "20%"
-    }
-  },
-  "w_25_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "25%"
-    }
-  },
-  "w_30_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "30%"
-    }
-  },
-  "w_33_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "33%"
-    }
-  },
-  "w_34_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "34%"
-    }
-  },
-  "w_40_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "40%"
-    }
-  },
-  "w_50_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "50%"
-    }
-  },
-  "w_60_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "60%"
-    }
-  },
-  "w_70_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "70%"
-    }
-  },
-  "w_75_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "75%"
-    }
-  },
-  "w_80_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "80%"
-    }
-  },
-  "w_90_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "90%"
-    }
-  },
-  "w_100_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "100%"
-    }
-  },
-  "w_third_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "calc(100% / 3)"
-    }
-  },
-  "w_two_thirds_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "calc(100% / 1.5)"
-    }
-  },
-  "w_auto_l": {
-    "@media screen and (min-width: 60em)": {
-      "width": "auto"
+      "vertical-align": "bottom"
     }
   },
   ":hover": {
-    "transition": "color .15s ease-in"
-  },
-  "underline_hover": {
-    ":hover": {
-      "text-decoration": "underline"
-    }
-  },
-  "pointer": {
-    ":hover": {
-      "cursor": "pointer"
-    }
+    "transition": "background-color .15s ease-in-out"
   },
   "hover_black": {
     ":hover": {
@@ -8468,6 +8461,16 @@ module.exports = {
   "hover_bg_washed_red": {
     ":hover": {
       "background-color": "var(--washed-red)"
+    }
+  },
+  "underline_hover": {
+    ":hover": {
+      "text-decoration": "underline"
+    }
+  },
+  "pointer": {
+    ":hover": {
+      "cursor": "pointer"
     }
   }
 }

--- a/whitelist.js
+++ b/whitelist.js
@@ -35,7 +35,7 @@ module.exports = [
     'tachyons-skins',
     'tachyons-skins-pseudo',
     'tachyons-spacing',
-    'tachyons-negative-margin',
+    // 'tachyons-negative-margin',
     'tachyons-tables',
     'tachyons-text-decoration',
     'tachyons-text-align',
@@ -48,6 +48,5 @@ module.exports = [
     'tachyons-vertical-align',
     'tachyons-hovers',
     'tachyons-z-index',
-    'tachyons-modular-nested',
-    'tachyons-styles'
+    'tachyons-modular-nested'
 ];


### PR DESCRIPTION
I removed tachyons-modules from generate.js and replaced it with a Promise.all() method at the end of the file.

I also commented out 'tachyons-negative-margin' from the white list, as I noticed that the npm that's replying it on is out-of-date with the current Tachyons CSS file. Currently, there is no replacement for it at the moment.